### PR TITLE
Correct asPillar for inline bocks to handle nested inline blocks 

### DIFF
--- a/src/Microdown-Tests/MicInlineSplitterTest.class.st
+++ b/src/Microdown-Tests/MicInlineSplitterTest.class.st
@@ -21,6 +21,18 @@ MicInlineSplitterTest >> testBasicTextAsPillar [
 ]
 
 { #category : #'pillar conversion' }
+MicInlineSplitterTest >> testBoldAndNestedItalicAsPillar [
+	| res |
+	res := self splitter pillarFrom: 'abc**x_y_z**cba'.
+	self assert: res second class equals: PRBoldFormat.
+	self assert: res second children first text equals: 'x'.
+	self assert: res second children second class equals: PRItalicFormat.
+	self assert: res second children second children first text equals: 'y'.
+	self assert: res second children third text equals: 'z'.
+	
+]
+
+{ #category : #'pillar conversion' }
 MicInlineSplitterTest >> testBoldAsPillar [
 	| res |
 	res := self splitter pillarFrom: 'abc**xyz**cba'.

--- a/src/Microdown/MicAbstractInlineBlock.class.st
+++ b/src/Microdown/MicAbstractInlineBlock.class.st
@@ -34,8 +34,14 @@ MicAbstractInlineBlock class >> from: aStartInteger to: anEndInteger withKind: a
 
 { #category : #converting }
 MicAbstractInlineBlock >> asPillar [
+	| childrenAsPillar |
+	
+	(self isOnlyChild) 
+		ifTrue: [ childrenAsPillar := {(PRText new text: self substring )} ] 
+		ifFalse: [ childrenAsPillar := children collect: [:e | e asPillar ] ].
+			
 	^ (self class associatedPRClass) new
-				setChildren: {(PRText new text: self substring )};
+				setChildren: childrenAsPillar;
 				yourself
 ]
 


### PR DESCRIPTION
+ test bold and italic nested asPillar in MicroDown-Tests