### PR TITLE
Fix annotation blocks and annotation inline blocks

### DIFF
--- a/src/Microdown-Tests/MicInlineSplitterTest.class.st
+++ b/src/Microdown-Tests/MicInlineSplitterTest.class.st
@@ -12,6 +12,15 @@ MicInlineSplitterTest >> splitter [
 	^ MicInlineSplitter new
 ]
 
+{ #category : #tests }
+MicInlineSplitterTest >> testAnnotationAsPillar [
+	| res |
+	res := self splitter pillarFrom: 'abc<?cite|a=2&b=5?>def'.
+	self assert: res second class equals: PRCitationAnnotation.
+	self assert: (res second parameters at: 'a') equals: '2'.
+	self assert: (res second parameters at: 'b') equals: '5'.
+]
+
 { #category : #'pillar conversion' }
 MicInlineSplitterTest >> testBasicTextAsPillar [
 	| res |

--- a/src/Microdown-Tests/MicInlineSplitterTest.class.st
+++ b/src/Microdown-Tests/MicInlineSplitterTest.class.st
@@ -20,6 +20,17 @@ MicInlineSplitterTest >> testBasicTextAsPillar [
 	self assert: res first class equals: PRText.
 ]
 
+{ #category : #tests }
+MicInlineSplitterTest >> testBoldAndNestedItalicAsPillar [
+	| res |
+	res := self splitter pillarFrom: 'abc**x_y_z**cba'.
+	self assert: res second class equals: PRBoldFormat.
+	self assert: res second children first text equals: 'x'.
+	self assert: res second children second class equals: PRItalicFormat.
+	self assert: res second children second children first text equals: 'y'.
+	self assert: res second children third text equals: 'z'
+]
+
 { #category : #'pillar conversion' }
 MicInlineSplitterTest >> testBoldAsPillar [
 	| res |
@@ -100,6 +111,15 @@ MicInlineSplitterTest >> testItalicAsPillar [
 	self assert: res second class equals: PRItalicFormat.
 	
 	
+]
+
+{ #category : #tests }
+MicInlineSplitterTest >> testSplitAnnotation [
+	| res |
+	res := self splitter start: 'abc<?type:value|key1=val1&key2=val2?>def'.
+	self
+		assert: (res collect: [ :x | x printString ])
+		equals: {'abc' . '[type:value|key1=val1&key2=val2](annotation)' . 'def'}.
 ]
 
 { #category : #tests }

--- a/src/Microdown-Tests/MicroDownParserTest.class.st
+++ b/src/Microdown-Tests/MicroDownParserTest.class.st
@@ -226,6 +226,24 @@ MicroDownParserTest >> testEnvironment [
 	
 ]
 
+{ #category : #tests }
+MicroDownParserTest >> testEnvironmentCitationWithArgumentsAsPillar [
+	| source root environment environmentName contents pillar |
+	environmentName := 'cite'.
+	contents := 'Hello
+
+Pharo'.
+	source := parser environmentOpeningBlockMarkup, environmentName, parser argumentListStartDelimiter, 'a=1&b=17&c'
+		, String cr , contents , String cr
+		, parser environmentClosingBlockMarkup , String cr.
+	root := parser parse: source.
+	pillar := root asPillar.
+	self assert: pillar children first class equals: PRCitationAnnotation.
+	self assert: (pillar children first parameters at: 'a') equals: '1'.
+	self assert: (pillar children first parameters at: 'b') equals: '17'.
+	self assert: (pillar children first parameters at: 'c') equals: nil.
+]
+
 { #category : #'tests-environment' }
 MicroDownParserTest >> testEnvironmentEatsNonClosedCodeMarkup [
 	| source root math environmentName contents |

--- a/src/Microdown/MicAbstractInlineBlock.class.st
+++ b/src/Microdown/MicAbstractInlineBlock.class.st
@@ -34,8 +34,14 @@ MicAbstractInlineBlock class >> from: aStartInteger to: anEndInteger withKind: a
 
 { #category : #converting }
 MicAbstractInlineBlock >> asPillar [
+	| childrenAsPillar |
+	
+	(self isOnlyChild) 
+		ifTrue: [ childrenAsPillar := {(PRText new text: self substring )} ] 
+		ifFalse: [ childrenAsPillar := children collect: [:e | e asPillar ] ].
+			
 	^ (self class associatedPRClass) new
-				setChildren: {(PRText new text: self substring )};
+				setChildren: childrenAsPillar;
 				yourself
 ]
 

--- a/src/Microdown/MicAnchorReferenceInlineBlock.class.st
+++ b/src/Microdown/MicAnchorReferenceInlineBlock.class.st
@@ -3,3 +3,8 @@ Class {
 	#superclass : #MicAbstractInlineBlock,
 	#category : #'Microdown-ModelInline'
 }
+
+{ #category : #'pillar conversion' }
+MicAnchorReferenceInlineBlock class >> associatedPRClass [
+	^ PRReference 
+]

--- a/src/Microdown/MicAnnotationInlineBlock.class.st
+++ b/src/Microdown/MicAnnotationInlineBlock.class.st
@@ -1,5 +1,30 @@
 Class {
 	#name : #MicAnnotationInlineBlock,
 	#superclass : #MicAbstractInlineBlock,
+	#instVars : [
+		'name',
+		'arguments'
+	],
 	#category : #'Microdown-ModelInline'
 }
+
+{ #category : #accessing }
+MicAnnotationInlineBlock >> arguments [
+	^ arguments
+]
+
+{ #category : #converting }
+MicAnnotationInlineBlock >> asPillar [
+	| lineStream resultArray micBlock |
+	micBlock := MicEnvironmentBlock new.
+	lineStream := substring readStream.
+	resultArray := micBlock findNameAndArguments: lineStream.
+	name := resultArray first.
+	arguments := resultArray second.
+	^ micBlock asPillarWithTag: name withParameters: arguments 
+]
+
+{ #category : #accessing }
+MicAnnotationInlineBlock >> name [
+	^ name
+]

--- a/src/Microdown/MicEnvironmentBlock.class.st
+++ b/src/Microdown/MicEnvironmentBlock.class.st
@@ -66,20 +66,34 @@ MicEnvironmentBlock >> arguments [
 
 { #category : #converting }
 MicEnvironmentBlock >> asPillar [
+	^ self asPillarWithTag: name withParameters: arguments
+]
+
+{ #category : #converting }
+MicEnvironmentBlock >> asPillarWithTag: aTag withParameters: aDictionnary [
 	| classPillar |
-	classPillar := PRAbstractAnnotation findClassAcceptingTag: name ifNone: [ PRUndefinedAnnotation ].
-	^ classPillar new parameters: arguments
+	classPillar := PRAbstractAnnotation findClassAcceptingTag: aTag ifNone: [ PRUndefinedAnnotation ].
+	^ classPillar new parameters: aDictionnary
 ]
 
 { #category : #accessing }
 MicEnvironmentBlock >> extractFirstLineFrom: aLine [
 
-	| lineWithoutMarkup lineStream |
+	| lineWithoutMarkup lineStream resultArray |
 	lineWithoutMarkup := super extractFirstLineFrom: aLine.
 	lineStream := lineWithoutMarkup readStream.
-	name := lineStream upTo: parser argumentListStartDelimiter first.
-	arguments := ZnResourceMetaUtils parseQueryFrom: lineStream.
+	resultArray := self findNameAndArguments: lineStream.
+	name := resultArray first.
+	arguments := resultArray second.
 	^ lineWithoutMarkup
+]
+
+{ #category : #'as yet unclassified' }
+MicEnvironmentBlock >> findNameAndArguments: aStream [
+	| foundName foundArguments | 
+	foundName := aStream upTo: self parserClass argumentListStartDelimiter first.
+	foundArguments := ZnResourceMetaUtils parseQueryFrom: aStream.
+	^ { foundName . foundArguments } asArray
 ]
 
 { #category : #markups }

--- a/src/Microdown/MicEnvironmentBlock.class.st
+++ b/src/Microdown/MicEnvironmentBlock.class.st
@@ -64,6 +64,13 @@ MicEnvironmentBlock >> arguments [
 	^ arguments
 ]
 
+{ #category : #converting }
+MicEnvironmentBlock >> asPillar [
+	| classPillar |
+	classPillar := PRAbstractAnnotation findClassAcceptingTag: name ifNone: [ PRUndefinedAnnotation ].
+	^ classPillar new parameters: arguments
+]
+
 { #category : #accessing }
 MicEnvironmentBlock >> extractFirstLineFrom: aLine [
 


### PR DESCRIPTION
FIX:
- nested inline blocks in asPillar (+green test)
- blocks and inline blocks annotation `<? .. ?>` : parse arguments , asPillar is working + green test