### PR TITLE
Add isEvaluated method for inline blocks

### DIFF
--- a/src/Microdown-Tests/MicInlineSplitterTest.class.st
+++ b/src/Microdown-Tests/MicInlineSplitterTest.class.st
@@ -13,6 +13,16 @@ MicInlineSplitterTest >> splitter [
 ]
 
 { #category : #tests }
+MicInlineSplitterTest >> testAnchorReferenceUnevaluated [
+	"When isEvaluated class method returns false, like anchor reference's case, inline inside shoudn't be evaluated"
+	| res |
+	res := self splitter start: 'abc*@def**not bold**ghi@*xyz'.
+	self
+		assert: (res collect: [ :x | x printString ])
+		equals: {'abc' . '[def**not bold**ghi](anchorReference)' . 'xyz'}
+]
+
+{ #category : #tests }
 MicInlineSplitterTest >> testAnnotationAsPillar [
 	| res |
 	res := self splitter pillarFrom: 'abc<?cite|a=2&b=5?>def'.
@@ -123,6 +133,36 @@ MicInlineSplitterTest >> testItalicAsPillar [
 ]
 
 { #category : #tests }
+MicInlineSplitterTest >> testMathUnevaluated [
+	"When isEvaluated class method returns false, like math's case, inline inside shoudn't be evaluated"
+	| res |
+	res := self splitter start: 'abc$def**not bold**ghi$xyz'.
+	self
+		assert: (res collect: [ :x | x printString ])
+		equals: {'abc' . '[def**not bold**ghi](math)' . 'xyz'}
+]
+
+{ #category : #tests }
+MicInlineSplitterTest >> testMonospaceUnevaluated [
+	"When isEvaluated class method returns false, like monospace's case, inline inside shoudn't be evaluated"
+	| res |
+	res := self splitter start: 'abc`def**not bold**ghi`xyz'.
+	self
+		assert: (res collect: [ :x | x printString ])
+		equals: {'abc' . '[def**not bold**ghi](monospace)' . 'xyz'}
+]
+
+{ #category : #tests }
+MicInlineSplitterTest >> testRawUnevaluated [
+	"When isEvaluated class method returns false, like raw's case, inline inside shoudn't be evaluated"
+	| res |
+	res := self splitter start: 'abc{{def**not bold**ghi}}xyz'.
+	self
+		assert: (res collect: [ :x | x printString ])
+		equals: {'abc' . '[def**not bold**ghi](raw)' . 'xyz'}
+]
+
+{ #category : #tests }
 MicInlineSplitterTest >> testSplitAnnotation [
 	| res |
 	res := self splitter start: 'abc<?type:value|key1=val1&key2=val2?>def'.
@@ -150,16 +190,6 @@ MicInlineSplitterTest >> testSplitBlockAnchorReference [
 		assert: (res collect: [ :x | x printString ])
 		equals: {'abc' . '[anchorA](anchorReference)' . 'def'}.
 	self assert: (res second isKindOf: MicAnchorReferenceInlineBlock)
-
-]
-
-{ #category : #tests }
-MicInlineSplitterTest >> testSplitBlockAnchorReferenceWithBold [
-	| res |
-	res := self splitter start: 'abc*@an**ch**orA@*def'.
-	self assert: (res second isKindOf: MicAnchorReferenceInlineBlock).
-	self assert: (res second children second isKindOf: MicBoldInlineBlock).
-	self assert: (res second children second substring) equals: 'ch'.
 
 ]
 

--- a/src/Microdown/MicAbstractInlineBlock.class.st
+++ b/src/Microdown/MicAbstractInlineBlock.class.st
@@ -33,6 +33,11 @@ MicAbstractInlineBlock class >> from: aStartInteger to: anEndInteger withKind: a
 		cleanSubstring; yourself.	
 ]
 
+{ #category : #testing }
+MicAbstractInlineBlock class >> isEvaluated [
+	^ true
+]
+
 { #category : #accessing }
 MicAbstractInlineBlock >> children [
 	^ children

--- a/src/Microdown/MicAnchorReferenceInlineBlock.class.st
+++ b/src/Microdown/MicAnchorReferenceInlineBlock.class.st
@@ -11,3 +11,8 @@ Class {
 	#superclass : #MicAbstractInlineBlock,
 	#category : #'Microdown-ModelInline'
 }
+
+{ #category : #testing }
+MicAnchorReferenceInlineBlock class >> isEvaluated [
+	^ false
+]

--- a/src/Microdown/MicInlineEmphasisProcessor.class.st
+++ b/src/Microdown/MicInlineEmphasisProcessor.class.st
@@ -172,7 +172,7 @@ MicInlineEmphasisProcessor >> processEmphasis [
 
 { #category : #actions }
 MicInlineEmphasisProcessor >> processNestedCase [
-	children := (associateCloserIndex = (firstOpenerIndex + 1))
+	children := ((associateCloserIndex = (firstOpenerIndex + 1)) or: (firstOpener associatedInlineBlock isEvaluated) not)
 		ifTrue: [ #() ]
 		ifFalse: [ self childrenInNestedCase ]
 ]

--- a/src/Microdown/MicMathInlineBlock.class.st
+++ b/src/Microdown/MicMathInlineBlock.class.st
@@ -9,3 +9,8 @@ Class {
 	#superclass : #MicAbstractInlineBlock,
 	#category : #'Microdown-ModelInline'
 }
+
+{ #category : #testing }
+MicMathInlineBlock class >> isEvaluated [
+	^ false
+]

--- a/src/Microdown/MicMonospaceInlineBlock.class.st
+++ b/src/Microdown/MicMonospaceInlineBlock.class.st
@@ -3,3 +3,8 @@ Class {
 	#superclass : #MicAbstractInlineBlock,
 	#category : #'Microdown-ModelInline'
 }
+
+{ #category : #testing }
+MicMonospaceInlineBlock class >> isEvaluated [
+	^ false
+]

--- a/src/Microdown/MicRawInlineBlock.class.st
+++ b/src/Microdown/MicRawInlineBlock.class.st
@@ -3,3 +3,8 @@ Class {
 	#superclass : #MicAbstractInlineBlock,
 	#category : #'Microdown-ModelInline'
 }
+
+{ #category : #testing }
+MicRawInlineBlock class >> isEvaluated [
+	^ false
+]


### PR DESCRIPTION
Add method isEvaluated
Override it for anchorReference, math, monospace, raw

Thus unevaluated inline blocks are not parsed inside

+ tests to prove unevaluation works (testMonospaceUnevaluated for instance)