### PR TITLE
New inline parsinig strategy

### DIFF
--- a/src/Microdown-Pillar/MicAbstractBlock.extension.st
+++ b/src/Microdown-Pillar/MicAbstractBlock.extension.st
@@ -3,5 +3,5 @@ Extension { #name : #MicAbstractBlock }
 { #category : #'*Microdown-Pillar' }
 MicAbstractBlock >> pillarFromString: aString [
 	
-	^ MicInlineSplitter new pillarFrom: aString
+	^ MicInlineSplitterOld new pillarFrom: aString
 ]

--- a/src/Microdown-Pillar/MicAbstractInlineBlockWithUrl.extension.st
+++ b/src/Microdown-Pillar/MicAbstractInlineBlockWithUrl.extension.st
@@ -3,7 +3,7 @@ Extension { #name : #MicAbstractInlineBlockWithUrl }
 { #category : #'*Microdown-Pillar' }
 MicAbstractInlineBlockWithUrl >> asPillar [
 	^ self class associatedPillarClass new
-		setChildren: ((MicInlineSplitter new start: self substring) collect: [:n | n asPillar]);
+		setChildren: ((MicInlineSplitterOld new start: self substring) collect: [:n | n asPillar]);
 		reference: self url;
 		yourself
 ]

--- a/src/Microdown-Tests/MicInlineSplitterTest.class.st
+++ b/src/Microdown-Tests/MicInlineSplitterTest.class.st
@@ -278,13 +278,12 @@ MicInlineSplitterTest >> testSplitBlockLinkInlineImage [
 	"Test the link annotation [![alttext](imageurl)](url)"
 
 	| res |
-	self skip.
 	res := self splitter
 		start: 'abc[![alttext](imageurl)](url)last'.
 	self
 		assert: (res collect: [ :x | x printString ])
-		equals: {'abc' . '[[alttext](figure)](linkName)' . 'last'}.
-	self assert: res second children second url equals: 'imageurl'
+		equals: {'abc' . '[ [alttext](figure) ](linkName)' . 'last'}.
+	self assert: res second children second url segments first equals: 'imageurl'
 ]
 
 { #category : #'tests - OK for now' }

--- a/src/Microdown-Tests/MicInlineSplitterTest.class.st
+++ b/src/Microdown-Tests/MicInlineSplitterTest.class.st
@@ -309,6 +309,16 @@ MicInlineSplitterTest >> testSplitBlockNested [
 ]
 
 { #category : #'tests - OK for now' }
+MicInlineSplitterTest >> testSplitBlockNested2 [
+	"Test with nested annotations"
+	| res |
+	res := self splitter start: 'abc**bold_italic_bold_italic2_bold**xyz'.
+	self
+		assert: (res collect: [ :x | x printString ])
+		equals: {'abc' . '[bold [italic](italic) bold [italic2](italic) bold](bold)' . 'xyz'}
+]
+
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testSplitBlockNoAnnotation [
 	| res |
 	res := self splitter start: 'abc'.

--- a/src/Microdown-Tests/MicInlineSplitterTest.class.st
+++ b/src/Microdown-Tests/MicInlineSplitterTest.class.st
@@ -7,7 +7,7 @@ Class {
 	#category : #'Microdown-Tests'
 }
 
-{ #category : #tests }
+{ #category : #access }
 MicInlineSplitterTest >> splitter [
 	^ MicInlineSplitter new
 ]

--- a/src/Microdown-Tests/MicInlineSplitterTest.class.st
+++ b/src/Microdown-Tests/MicInlineSplitterTest.class.st
@@ -12,7 +12,7 @@ MicInlineSplitterTest >> splitter [
 	^ MicInlineSplitter new
 ]
 
-{ #category : #tests }
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testAnchorReferenceUnevaluated [
 	"When isEvaluated class method returns false, like anchor reference's case, inline inside shoudn't be evaluated"
 	| res |
@@ -30,7 +30,7 @@ MicInlineSplitterTest >> testBasicTextAsPillar [
 	self assert: res first class equals: PRText.
 ]
 
-{ #category : #tests }
+{ #category : #'pillar conversion' }
 MicInlineSplitterTest >> testBoldAndNestedItalicAsPillar [
 	| res |
 	res := self splitter pillarFrom: 'abc**x_y_z**cba'.
@@ -49,7 +49,7 @@ MicInlineSplitterTest >> testBoldAsPillar [
 	self assert: res second class equals: PRBoldFormat.
 ]
 
-{ #category : #tests }
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testEscapeCharacter [
 	"Test the escape \ in simple case (here, bold one)"
 
@@ -60,7 +60,7 @@ MicInlineSplitterTest >> testEscapeCharacter [
 		equals: {'abc**test**last'}.
 ]
 
-{ #category : #tests }
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testEscapeCharacterAtBeginning [
 	"Test the escape \ in simple case (here, bold one)"
 
@@ -71,7 +71,7 @@ MicInlineSplitterTest >> testEscapeCharacterAtBeginning [
 		equals: {'**test**'}.
 ]
 
-{ #category : #tests }
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testEscapeCharacterInLinkName [
 	"Test the escape \ in link description"
 
@@ -82,7 +82,7 @@ MicInlineSplitterTest >> testEscapeCharacterInLinkName [
 		equals: {'abc' . '[**test**](linkName)' . 'last'}.
 ]
 
-{ #category : #tests }
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testEscapeCharacterInNestedLinkName [
 	"Test the escape \ in case of nested linknames"
 
@@ -121,7 +121,7 @@ MicInlineSplitterTest >> testItalicAsPillar [
 	
 ]
 
-{ #category : #tests }
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testMathUnevaluated [
 	"When isEvaluated class method returns false, like math's case, inline inside shoudn't be evaluated"
 	| res |
@@ -131,7 +131,7 @@ MicInlineSplitterTest >> testMathUnevaluated [
 		equals: {'abc' . '[def**not bold**ghi](math)' . 'xyz'}
 ]
 
-{ #category : #tests }
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testMonospaceUnevaluated [
 	"When isEvaluated class method returns false, like monospace's case, inline inside shoudn't be evaluated"
 	| res |
@@ -141,7 +141,7 @@ MicInlineSplitterTest >> testMonospaceUnevaluated [
 		equals: {'abc' . '[def**not bold**ghi](monospace)' . 'xyz'}
 ]
 
-{ #category : #tests }
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testRawUnevaluated [
 	"When isEvaluated class method returns false, like raw's case, inline inside shoudn't be evaluated"
 	| res |
@@ -151,7 +151,7 @@ MicInlineSplitterTest >> testRawUnevaluated [
 		equals: {'abc' . '[def**not bold**ghi](raw)' . 'xyz'}
 ]
 
-{ #category : #tests }
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testSplitAnnotation [
 	| res |
 	res := self splitter start: 'abc<?type:value|key1=val1&key2=val2?>def'.
@@ -160,7 +160,7 @@ MicInlineSplitterTest >> testSplitAnnotation [
 		equals: {'abc' . '[type:value|key1=val1&key2=val2](annotation)' . 'def'}.
 ]
 
-{ #category : #tests }
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testSplitBlock2 [
 	"Test with multiple annotations"
 
@@ -171,7 +171,7 @@ MicInlineSplitterTest >> testSplitBlock2 [
 		equals: {'abc' . '[abc](bold)' . 'xyz' . '[xyz](monospace)' . 'last'}
 ]
 
-{ #category : #tests }
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testSplitBlockAnchorReference [
 	| res |
 	res := self splitter start: 'abc*@anchorA@*def'.
@@ -182,7 +182,7 @@ MicInlineSplitterTest >> testSplitBlockAnchorReference [
 
 ]
 
-{ #category : #tests }
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testSplitBlockAnnotation [
 	| res |
 	res := self splitter start: 'abc<?an annotation?>def'.
@@ -193,7 +193,7 @@ MicInlineSplitterTest >> testSplitBlockAnnotation [
 
 ]
 
-{ #category : #tests }
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testSplitBlockBold [
 	| res |
 	res := self splitter start: 'abc**bold**def'.
@@ -210,7 +210,7 @@ MicInlineSplitterTest >> testSplitBlockBold [
 
 ]
 
-{ #category : #tests }
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testSplitBlockCode [
 	| res |
 	res := self splitter start: 'abc`block`def'.
@@ -219,7 +219,7 @@ MicInlineSplitterTest >> testSplitBlockCode [
 		equals: {'abc' . '[block](monospace)' . 'def'}.
 ]
 
-{ #category : #tests }
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testSplitBlockImage [
 	"Test the image annotation ![AltText](url)"
 
@@ -233,7 +233,7 @@ MicInlineSplitterTest >> testSplitBlockImage [
 	self assert: res second url segments second equals: 'image.png'	
 ]
 
-{ #category : #tests }
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testSplitBlockItalics [
 	| res |
 	res := self splitter start: 'abc_italics_def'.
@@ -247,7 +247,7 @@ MicInlineSplitterTest >> testSplitBlockItalics [
 		equals: {'abc' . '[ ita lics ](italic)' . 'def'}.
 ]
 
-{ #category : #tests }
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testSplitBlockLink [
 	"Test the link annotation [LinkText](url)"
 
@@ -260,7 +260,7 @@ MicInlineSplitterTest >> testSplitBlockLink [
 	self assert: res second url segments first equals: 'myURL'
 ]
 
-{ #category : #tests }
+{ #category : #fails }
 MicInlineSplitterTest >> testSplitBlockLinkIncomplete [
 	"Test the annotation [LinkText] -> should return a link with url as linktext"
 
@@ -273,7 +273,7 @@ MicInlineSplitterTest >> testSplitBlockLinkIncomplete [
 	self assert: res second url equals: 'LinkText'
 ]
 
-{ #category : #tests }
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testSplitBlockLinkInlineImage [
 	"Test the link annotation [![alttext](imageurl)](url)"
 
@@ -287,7 +287,7 @@ MicInlineSplitterTest >> testSplitBlockLinkInlineImage [
 	self assert: res second children second url equals: 'imageurl'
 ]
 
-{ #category : #tests }
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testSplitBlockMultipleSequenceAnnotation [
 	"Test with multiple annotations"
 
@@ -298,7 +298,7 @@ MicInlineSplitterTest >> testSplitBlockMultipleSequenceAnnotation [
 		equals: {'abc' . '[abc](bold)' . 'xyz' . '[xyz](monospace)' . 'last'}
 ]
 
-{ #category : #tests }
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testSplitBlockNested [
 	"Test with nested annotations"
 	| res |
@@ -308,7 +308,7 @@ MicInlineSplitterTest >> testSplitBlockNested [
 		equals: {'abc' . '[bold [italic](italic) bold](bold)' . 'xyz'}
 ]
 
-{ #category : #tests }
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testSplitBlockNoAnnotation [
 	| res |
 	res := self splitter start: 'abc'.
@@ -318,7 +318,7 @@ MicInlineSplitterTest >> testSplitBlockNoAnnotation [
 	self assert: res first printString equals: 'abc def gh'.
 ]
 
-{ #category : #tests }
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testSplitBlockStrike [
 	| res |
 	res := self splitter start: 'abc~strike~def'.
@@ -327,14 +327,14 @@ MicInlineSplitterTest >> testSplitBlockStrike [
 		equals: {'abc' . '[strike](strike)' . 'def'}.
 ]
 
-{ #category : #tests }
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testSplitEmpty [
 	| res |
 	res := self splitter start: ''.
 	self assert: res isEmpty
 ]
 
-{ #category : #tests }
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testSplitExclamationMark [
 	"Test that 'bla!bla' is ok, and not a failed image, same goes for '![goo]no parenthesis'"
 
@@ -349,7 +349,7 @@ MicInlineSplitterTest >> testSplitExclamationMark [
 		equals: {'![goo]no parenthesis'}
 ]
 
-{ #category : #tests }
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testSplitMathCode [
 	| res |
 	res := self splitter start: 'abc$math env$def'.
@@ -358,7 +358,7 @@ MicInlineSplitterTest >> testSplitMathCode [
 		equals: {'abc' . '[math env](math)' . 'def'}.
 ]
 
-{ #category : #tests }
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testSplitMathRaw [
 	| res |
 	res := self splitter start: 'abc{{someRaw}}def'.
@@ -367,14 +367,14 @@ MicInlineSplitterTest >> testSplitMathRaw [
 		equals: {'abc' . '[someRaw](raw)' . 'def'}.
 ]
 
-{ #category : #tests }
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testSplitNotClosed [
 	| res |
 	res := self splitter start: 'abc**xyz'.
 	self assert: res first printString equals: 'abc**xyz'.
 ]
 
-{ #category : #tests }
+{ #category : #'tests - OK for now' }
 MicInlineSplitterTest >> testUrlObjectInUrlBlocks [
 
 	| res |

--- a/src/Microdown-Tests/MicParagraphBlockTest.class.st
+++ b/src/Microdown-Tests/MicParagraphBlockTest.class.st
@@ -36,8 +36,8 @@ a paragraph on two lines**'.
 another line** and more'.
 	self assert: root children second text equals: 'a paragraph on two lines**'.
 	
-	self assert: (MicInlineSplitter new start: root children first text) first kind equals: #bold.
-	self assert: (MicInlineSplitter new start: root children second text) first kind equals: #basic.
+	self assert: (MicInlineSplitterOld new start: root children first text) first kind equals: #bold.
+	self assert: (MicInlineSplitterOld new start: root children second text) first kind equals: #basic.
 ]
 
 { #category : #tests }

--- a/src/Microdown/MicAbstractBlock.class.st
+++ b/src/Microdown/MicAbstractBlock.class.st
@@ -134,5 +134,5 @@ MicAbstractBlock >> showStructure: indent [
 MicAbstractBlock >> splitString: aString [
 	self flag: #fixMe.
 	"rename me as handleDecorations: and it should be private interface."
-	^ MicInlineSplitter new start: aString
+	^ MicInlineSplitterOld new start: aString
 ]

--- a/src/Microdown/MicAbstractDelimiter.class.st
+++ b/src/Microdown/MicAbstractDelimiter.class.st
@@ -38,14 +38,29 @@ MicAbstractDelimiter class >> isActive [
 	^ true
 ]
 
+{ #category : #testing }
+MicAbstractDelimiter class >> isBoth [
+	^ self isCloser and: self isOpener
+]
+
 { #category : #accessing }
 MicAbstractDelimiter class >> isCloser [
 	^ self subclassResponsibility 
 ]
 
+{ #category : #testing }
+MicAbstractDelimiter class >> isCloserOnly [
+	^ self isCloser and: self isOpener not
+]
+
 { #category : #accessing }
 MicAbstractDelimiter class >> isOpener [
 	^ self subclassResponsibility 
+]
+
+{ #category : #testing }
+MicAbstractDelimiter class >> isOpenerOnly [
+	^ self isCloser not and: self isOpener
 ]
 
 { #category : #accessing }

--- a/src/Microdown/MicAbstractInlineBlock.class.st
+++ b/src/Microdown/MicAbstractInlineBlock.class.st
@@ -23,6 +23,17 @@ Class {
 }
 
 { #category : #constructor }
+MicAbstractInlineBlock class >> from: aStartInteger to: anEndInteger withKind: aKind withSubstring: aString [
+	^ self new 
+		start: aStartInteger; 
+		end: anEndInteger; 
+		kind: aKind; 
+		substring: aString; 
+		children: Array empty; 
+		cleanSubstring; yourself.	
+]
+
+{ #category : #constructor }
 MicAbstractInlineBlock class >> from: aStartInteger to: anEndInteger withKind: aKind withSubstring: aString withChildren: aChildren [
 	^ self new 
 		start: aStartInteger; 

--- a/src/Microdown/MicAbstractInlineBlockWithUrl.class.st
+++ b/src/Microdown/MicAbstractInlineBlockWithUrl.class.st
@@ -9,12 +9,12 @@ Class {
 
 { #category : #obsolete }
 MicAbstractInlineBlockWithUrl class >> from: aStartInteger to: anEndInteger withKind: aKind withSubstring: aString withChildren: aChildren withURL: aURL [
-	^ (self from: aStartInteger to: anEndInteger withKind: aKind withSubstring: aString withChildren: aChildren) url: aURL; urlTransformation; yourself
+	^ (self from: aStartInteger to: anEndInteger withKind: aKind withSubstring: aString withChildren: aChildren) url: aURL; yourself
 ]
 
 { #category : #obsolete }
 MicAbstractInlineBlockWithUrl class >> from: aStartInteger to: anEndInteger withKind: aKind withSubstring: aString withURL: aURL [
-	^ (self from: aStartInteger to: anEndInteger withKind: aKind withSubstring: aString withChildren: Array empty) url: aURL; urlTransformation; yourself
+	^ (self from: aStartInteger to: anEndInteger withKind: aKind withSubstring: aString withChildren: Array empty) url: aURL; yourself
 ]
 
 { #category : #accessing }
@@ -24,10 +24,5 @@ MicAbstractInlineBlockWithUrl >> url [
 
 { #category : #accessing }
 MicAbstractInlineBlockWithUrl >> url: anURL [
-	url := anURL
-]
-
-{ #category : #transformation }
-MicAbstractInlineBlockWithUrl >> urlTransformation [
-	self url: (ZnUrl fromString: self url)
+	url := (anURL isKindOf: ZnUrl) ifTrue: [anURL] ifFalse: [ ZnUrl fromString: anURL ]
 ]

--- a/src/Microdown/MicAbstractInlineBlockWithUrl.class.st
+++ b/src/Microdown/MicAbstractInlineBlockWithUrl.class.st
@@ -12,6 +12,11 @@ MicAbstractInlineBlockWithUrl class >> from: aStartInteger to: anEndInteger with
 	^ (self from: aStartInteger to: anEndInteger withKind: aKind withSubstring: aString withChildren: aChildren) url: aURL; urlTransformation; yourself
 ]
 
+{ #category : #obsolete }
+MicAbstractInlineBlockWithUrl class >> from: aStartInteger to: anEndInteger withKind: aKind withSubstring: aString withURL: aURL [
+	^ (self from: aStartInteger to: anEndInteger withKind: aKind withSubstring: aString withChildren: Array empty) url: aURL; urlTransformation; yourself
+]
+
 { #category : #accessing }
 MicAbstractInlineBlockWithUrl >> url [
 	^ url

--- a/src/Microdown/MicInlineSplitter.class.st
+++ b/src/Microdown/MicInlineSplitter.class.st
@@ -199,13 +199,20 @@ MicInlineSplitter >> linkOrFigureProcess: indexOfAssociateOpener [
 					correctSubstring := string collect: [ :c | c ] from: startIndex to: endIndex.
 					correctURL := string collect: [ :c | c ] from: (closer index + closer size + self urlOpenerDelimiterClass size) to: (urlCloserIndex - 1).
 					"Add found inline block"
-					result add: 
-						(opener associatedInlineBlock
-							from: opener index
-							to: urlCloserIndex 
-							withKind: opener type
-							withSubstring: correctSubstring
-							withURL: correctURL).
+			(openersStack size > 1)
+				ifTrue: [ 
+					(openersStack size - 1 > nestedLevel)
+						ifTrue: [ 
+							children 
+								ifEmpty: [ children add: ((self newInlineBlockWithCloser: urlCloserIndex) url: correctURL) ]
+								ifNotEmpty: [ children last add: ((self newInlineBlockWithCloser: urlCloserIndex) url: correctURL) ] ]
+						ifFalse: [ children add: ((self newInlineBlockWithoutChildrenWithCloser: urlCloserIndex) url: correctURL) ].
+				]
+				ifFalse: [ 
+					result add: ((self newInlineBlockWithCloser: urlCloserIndex) url: correctURL).
+					children := LinkedList new.
+				].
+			nestedLevel := openersStack size - 1.
 				"Delete openers above in stack, considered as unclosed so ignored"
 				self popFrom: 1 to: indexOfAssociateOpener.
 				incrementation := urlCloserIndex - index
@@ -243,10 +250,36 @@ MicInlineSplitter >> newInlineBlock [
 ]
 
 { #category : #'instance creation' }
+MicInlineSplitter >> newInlineBlockWithCloser: aCloserIndex [
+	| inlineBlockClass |
+	inlineBlockClass := opener associatedInlineBlock.
+	(inlineBlockClass isEvaluated) 
+		ifTrue: [ 
+			^ inlineBlockClass
+				from: opener index
+				to: aCloserIndex
+				withKind: opener type
+				withSubstring: correctSubstring
+				withChildren: children asArray
+		 ]
+		ifFalse: [ ^ self newInlineBlockWithoutChildren ]
+	
+]
+
+{ #category : #'instance creation' }
 MicInlineSplitter >> newInlineBlockWithoutChildren [
 	^ opener associatedInlineBlock
 			from: opener index
 			to: closer index + closer size - 1
+			withKind: opener type
+			withSubstring: correctSubstring
+]
+
+{ #category : #'instance creation' }
+MicInlineSplitter >> newInlineBlockWithoutChildrenWithCloser: aCloserIndex [
+	^ opener associatedInlineBlock
+			from: opener index
+			to: aCloserIndex
 			withKind: opener type
 			withSubstring: correctSubstring
 ]
@@ -291,7 +324,7 @@ MicInlineSplitter >> resultProcess [
 	result do: [ :e | 
 		| startSubstring endSubstring |
 		startSubstring := string indexOfSubCollection: e substring startingAt: e start.
-		endSubstring := startSubstring + e substring size - 1.		
+		endSubstring := startSubstring + e substring size - 1 .
 		e children: (self insertBasicText: e children from: startSubstring to: endSubstring) ].
 	^ self insertBasicText: result
 ]

--- a/src/Microdown/MicInlineSplitter.class.st
+++ b/src/Microdown/MicInlineSplitter.class.st
@@ -156,7 +156,6 @@ MicInlineSplitter >> linkOrFigureProcess: indexOfAssociateOpener withOpener: ope
 					correctSubstring := string collect: [ :c | c ] from: startIndex to: endIndex.
 					correctURL := string collect: [ :c | c ] from: (closer index + closer size + self urlOpenerDelimiterClass size) to: (urlCloserIndex - 1).
 					"Add found inline block"
-					self halt.
 					result add: 
 						(opener associatedInlineBlock
 							from: opener index

--- a/src/Microdown/MicInlineSplitter.class.st
+++ b/src/Microdown/MicInlineSplitter.class.st
@@ -76,23 +76,13 @@ MicInlineSplitter >> allDelimiters [
 
 { #category : #process }
 MicInlineSplitter >> bothCase [
-	openersStack 
-		ifEmpty: [ 
-			"It's the first opener"
-			self pushNewOpener
-		]
-		ifNotEmpty: [ 
-			(openersStack top type = delimiterSubclassFound type)
-			ifTrue: [ 
-				"We consider the delimiter as a closer of last opened inline block"
-				self addInlineBlock
-			 ]
-			ifFalse: [ 
-				"We consider the delimiter as a new opener"
-				self pushNewOpener
-			 ]
-		]
-	
+	(openersStack isEmpty or: [ (openersStack top type = delimiterSubclassFound type) not ])
+		ifTrue: [ 
+			"We consider the delimiter as a new opener or it's the first opener"
+			self pushNewOpener ]
+		ifFalse: [ 
+			"We consider the delimiter as a closer of last opened inline block"
+			self addInlineBlock ]
 ]
 
 { #category : #process }

--- a/src/Microdown/MicInlineSplitter.class.st
+++ b/src/Microdown/MicInlineSplitter.class.st
@@ -8,7 +8,13 @@ Class {
 		'index',
 		'string',
 		'incrementation',
-		'delimiterSubclassFound'
+		'delimiterSubclassFound',
+		'children',
+		'nestedLevel',
+		'opener',
+		'closer',
+		'correctSubstring',
+		'correctURL'
 	],
 	#category : #'Microdown-Parser'
 }
@@ -19,6 +25,13 @@ MicInlineSplitter >> abstractDelimiterClass [
 ]
 
 { #category : #adding }
+MicInlineSplitter >> addABasicTextFrom: start to: end toFinalArray: aFinalArray [
+	(start = end) 
+		ifTrue: [ " do nothing "]
+		ifFalse: [ aFinalArray add: (self newBasicInlineBlockFrom: start to: end ) ]
+]
+
+{ #category : #adding }
 MicInlineSplitter >> addInlineBlock [
 	"The found closer should match with the last opener, found at the top of openersStack e.g. at index 1"
 	self addInlineBlock: 1
@@ -26,23 +39,31 @@ MicInlineSplitter >> addInlineBlock [
 
 { #category : #adding }
 MicInlineSplitter >> addInlineBlock: indexOfAssociateOpener [
-	| opener closer startIndex endIndex correctSubstring |
+	| startIndex endIndex |
 	opener := openersStack at: indexOfAssociateOpener.
 	closer := delimiterSubclassFound index: index.
 	"Check the linkName or figure case"
 	(#(#linkName #figure) includes: opener type ) 
-		ifTrue: [ self linkOrFigureProcess: indexOfAssociateOpener withOpener: opener withCloser: closer]
+		ifTrue: [ self linkOrFigureProcess: indexOfAssociateOpener ]
 		ifFalse: [ 
 			startIndex := opener index + opener size.
 			endIndex := closer index - 1.
 			correctSubstring := string collect: [ :c | c ] from: startIndex to: endIndex.
 			"Add found inline block"
-			result add: 
-				(opener associatedInlineBlock
-					from: opener index
-					to: closer index + closer size - 1
-					withKind: opener type
-					withSubstring: correctSubstring).
+			(openersStack size > 1)
+				ifTrue: [ 
+					(openersStack size - 1 > nestedLevel)
+						ifTrue: [ 
+							children 
+								ifEmpty: [ children add: self newInlineBlock ]
+								ifNotEmpty: [ children last add: self newInlineBlock ] ]
+						ifFalse: [ children add: self newInlineBlockWithoutChildren ].
+				]
+				ifFalse: [ 
+					result add: self newInlineBlock.
+					children := LinkedList new.
+				].
+			nestedLevel := openersStack size - 1.
 			"Delete openers above in stack, considered as unclosed so ignored"
 			self popFrom: 1 to: indexOfAssociateOpener
 		]
@@ -127,6 +148,8 @@ MicInlineSplitter >> initialize [
 	self initializeDelimiters.
 	openersStack := Stack new.
 	result := LinkedList new.
+	children := LinkedList new.
+	nestedLevel := 0.
 	index := 1
 ]
 
@@ -140,12 +163,37 @@ MicInlineSplitter >> initializeDelimiters [
 										put: subclass ]
 ]
 
+{ #category : #'as yet unclassified' }
+MicInlineSplitter >> insertBasicText: anArrayOfInlineBlocks [
+	^ self insertBasicText: anArrayOfInlineBlocks withFinalArray: LinkedList new
+]
+
+{ #category : #'as yet unclassified' }
+MicInlineSplitter >> insertBasicText: anArrayOfInlineBlocks withFinalArray: finalArray [
+	anArrayOfInlineBlocks ifEmpty: [ ^ finalArray ].
+	(anArrayOfInlineBlocks size = 1) ifTrue: [ 
+		| element |
+		element := anArrayOfInlineBlocks first.
+		finalArray ifEmpty: [ self addABasicTextFrom: 1 to: element start - 1 toFinalArray: finalArray ].
+		finalArray add: element.
+		self addABasicTextFrom: element end + 1 to: string size toFinalArray: finalArray.
+		^ self insertBasicText: Array empty withFinalArray: finalArray
+	].
+	finalArray ifEmpty: [ self addABasicTextFrom: 1 to: anArrayOfInlineBlocks first start - 1toFinalArray: finalArray ].
+	finalArray add: anArrayOfInlineBlocks first.
+	self addABasicTextFrom: anArrayOfInlineBlocks first end + 1 to: anArrayOfInlineBlocks second start - 1 toFinalArray: finalArray.
+	^ self insertBasicText: anArrayOfInlineBlocks allButFirst withFinalArray: finalArray
+	
+	
+	
+]
+
 { #category : #process }
-MicInlineSplitter >> linkOrFigureProcess: indexOfAssociateOpener withOpener: opener withCloser: closer [
+MicInlineSplitter >> linkOrFigureProcess: indexOfAssociateOpener [
 	"IF we find a ( just after and a ) after again
 	THEN we add the associate link or figure inline block
 	ELSE we ignore it"
-	| startIndex endIndex urlCloserIndex correctSubstring correctURL |
+	| startIndex endIndex urlCloserIndex |
 	((string allButFirst: (closer index + closer size - 1)) beginsWith: self urlOpenerDelimiterClass markup)
 		ifTrue: [ 
 			urlCloserIndex := string indexOfSubCollection: self urlCloserDelimiterClass markup startingAt: closer index ifAbsent: [ 0 ].
@@ -172,6 +220,42 @@ MicInlineSplitter >> linkOrFigureProcess: indexOfAssociateOpener withOpener: ope
 		ifFalse: [ "do nothing" ]
 ]
 
+{ #category : #'instance creation' }
+MicInlineSplitter >> newBasicInlineBlockFrom: stIndex to: eIndex [
+	^ (MicBasicInlineBlock
+			from: stIndex
+			to: eIndex
+			withKind: #basic
+			withSubstring: (string collect: [ :c | c ] from: stIndex to: eIndex)
+			withChildren: Array empty)
+]
+
+{ #category : #'instance creation' }
+MicInlineSplitter >> newInlineBlock [
+	| inlineBlockClass |
+	inlineBlockClass := opener associatedInlineBlock.
+	(inlineBlockClass isEvaluated) 
+		ifTrue: [ 
+			^ inlineBlockClass
+				from: opener index
+				to: closer index + closer size - 1
+				withKind: opener type
+				withSubstring: correctSubstring
+				withChildren: children asArray
+		 ]
+		ifFalse: [ ^ self newInlineBlockWithoutChildren ]
+	
+]
+
+{ #category : #'instance creation' }
+MicInlineSplitter >> newInlineBlockWithoutChildren [
+	^ opener associatedInlineBlock
+			from: opener index
+			to: closer index + closer size - 1
+			withKind: opener type
+			withSubstring: correctSubstring
+]
+
 { #category : #process }
 MicInlineSplitter >> openerOnlyCase [
 	self pushNewOpener
@@ -191,7 +275,7 @@ MicInlineSplitter >> pushNewOpener [
 { #category : #'meta-object-protocol' }
 MicInlineSplitter >> read: aString [
 	incrementation := 1.
-	aString ifEmpty: [ "^ self resultProcess" ^ result ].
+	aString ifEmpty: [ ^ self resultProcess ].
 	allDelimiters keys do: [ :key | 
  		(aString beginsWith: key) 
 			ifTrue: [ 
@@ -205,8 +289,17 @@ MicInlineSplitter >> read: aString [
 	
 ]
 
+{ #category : #process }
+MicInlineSplitter >> resultProcess [
+	"At the end, we add all basic text between found inline blocks"
+	result ifEmpty: [ ^ (self newBasicInlineBlockFrom: 1 to: string size) asArray ].
+	result do: [ :e | e children: (self insertBasicText: e children ) ].
+	^ self insertBasicText: result
+]
+
 { #category : #accessing }
 MicInlineSplitter >> start: aString [
+	aString ifEmpty: [ ^ Array empty ].
 	string := aString.
 	^ self read: aString
 ]

--- a/src/Microdown/MicInlineSplitter.class.st
+++ b/src/Microdown/MicInlineSplitter.class.st
@@ -165,24 +165,29 @@ MicInlineSplitter >> initializeDelimiters [
 
 { #category : #'as yet unclassified' }
 MicInlineSplitter >> insertBasicText: anArrayOfInlineBlocks [
-	^ self insertBasicText: anArrayOfInlineBlocks withFinalArray: LinkedList new
+	^ self insertBasicText: anArrayOfInlineBlocks withFinalArray: LinkedList new from: 1 to: string size
 ]
 
 { #category : #'as yet unclassified' }
-MicInlineSplitter >> insertBasicText: anArrayOfInlineBlocks withFinalArray: finalArray [
-	anArrayOfInlineBlocks ifEmpty: [ ^ finalArray ].
+MicInlineSplitter >> insertBasicText: anArrayOfInlineBlocks from: startIndex to: endIndex [
+	^ self insertBasicText: anArrayOfInlineBlocks withFinalArray: LinkedList new from: startIndex to: endIndex
+]
+
+{ #category : #'as yet unclassified' }
+MicInlineSplitter >> insertBasicText: anArrayOfInlineBlocks withFinalArray: finalArray from: startIndex to: endIndex [
+	anArrayOfInlineBlocks ifEmpty: [ ^ finalArray asArray ].
 	(anArrayOfInlineBlocks size = 1) ifTrue: [ 
 		| element |
 		element := anArrayOfInlineBlocks first.
-		finalArray ifEmpty: [ self addABasicTextFrom: 1 to: element start - 1 toFinalArray: finalArray ].
+		finalArray ifEmpty: [ self addABasicTextFrom: startIndex to: element start - 1 toFinalArray: finalArray ].
 		finalArray add: element.
-		self addABasicTextFrom: element end + 1 to: string size toFinalArray: finalArray.
-		^ self insertBasicText: Array empty withFinalArray: finalArray
+		self addABasicTextFrom: element end + 1 to: endIndex toFinalArray: finalArray.
+		^ self insertBasicText: Array empty withFinalArray: finalArray from: startIndex to: endIndex
 	].
-	finalArray ifEmpty: [ self addABasicTextFrom: 1 to: anArrayOfInlineBlocks first start - 1toFinalArray: finalArray ].
+	finalArray ifEmpty: [ self addABasicTextFrom: startIndex to: anArrayOfInlineBlocks first start - 1 toFinalArray: finalArray ].
 	finalArray add: anArrayOfInlineBlocks first.
 	self addABasicTextFrom: anArrayOfInlineBlocks first end + 1 to: anArrayOfInlineBlocks second start - 1 toFinalArray: finalArray.
-	^ self insertBasicText: anArrayOfInlineBlocks allButFirst withFinalArray: finalArray
+	^ self insertBasicText: anArrayOfInlineBlocks allButFirst withFinalArray: finalArray from: startIndex to: endIndex
 	
 	
 	
@@ -293,7 +298,11 @@ MicInlineSplitter >> read: aString [
 MicInlineSplitter >> resultProcess [
 	"At the end, we add all basic text between found inline blocks"
 	result ifEmpty: [ ^ (self newBasicInlineBlockFrom: 1 to: string size) asArray ].
-	result do: [ :e | e children: (self insertBasicText: e children ) ].
+	result do: [ :e | 
+		| startSubstring endSubstring |
+		startSubstring := string indexOfSubCollection: e substring startingAt: e start.
+		endSubstring := startSubstring + e substring size - 1.		
+		e children: (self insertBasicText: e children from: startSubstring to: endSubstring) ].
 	^ self insertBasicText: result
 ]
 

--- a/src/Microdown/MicInlineSplitter.class.st
+++ b/src/Microdown/MicInlineSplitter.class.st
@@ -1,46 +1,14 @@
-"
-I represent the class which is in charge of splitting sentences to parse inline blocks.
-
-To proceed: `MicInlineSplitter new start: stringToParse`
-
-### Implementation: How parsing is made ? 
-- Read the string to parse and memorize all delimiters we meet in a collection
-- Start the `emphasisProcess`
-   - Search for the first opener delimiter in collection
-   - If it’s a link or a figure opener delimiter, start the `linkOrFigureProcess`
-     - Search for the associate closer
-     - Search for the following url
-     - Add it to the final array of inlines blocks
-   - Search for the associate closer
-   - Check if we have nested inline blocks (like bold in italic format)
-   - Add the found inline block to the final array of inlines blocks
-
-Note1: the escape delimiter is `\` (back slash)
-Note2: a new line in an inline paragraph doesn’t interfere with parsing. 
-The following example is totally bold:
-```
-		**Hello
-		world**
-```
-Note3: BUT a line between two lines must end the parsing process.
-The following example must not be bold:
-
-```
-		**Hello
-
-		world**
-```
-"
 Class {
 	#name : #MicInlineSplitter,
 	#superclass : #Object,
 	#instVars : [
-		'string',
-		'resultArray',
-		'index',
-		'delimiterStack',
+		'openersStack',
+		'result',
 		'allDelimiters',
-		'incrementation'
+		'index',
+		'string',
+		'incrementation',
+		'delimiterSubclassFound'
 	],
 	#category : #'Microdown-Parser'
 }
@@ -50,45 +18,119 @@ MicInlineSplitter >> abstractDelimiterClass [
 	^ MicAbstractDelimiter
 ]
 
-{ #category : #accessing }
+{ #category : #adding }
+MicInlineSplitter >> addInlineBlock [
+	"The found closer should match with the last opener, found at the top of openersStack e.g. at index 1"
+	self addInlineBlock: 1
+]
+
+{ #category : #adding }
+MicInlineSplitter >> addInlineBlock: indexOfAssociateOpener [
+	| opener closer startIndex endIndex correctSubstring |
+	opener := openersStack at: indexOfAssociateOpener.
+	closer := delimiterSubclassFound index: index.
+	"Check the linkName or figure case"
+	(#(#linkName #figure) includes: opener type ) 
+		ifTrue: [ self linkOrFigureProcess: indexOfAssociateOpener withOpener: opener withCloser: closer]
+		ifFalse: [ 
+			startIndex := opener index + opener size.
+			endIndex := closer index - 1.
+			correctSubstring := string collect: [ :c | c ] from: startIndex to: endIndex.
+			"Add found inline block"
+			result add: 
+				(opener associatedInlineBlock
+					from: opener index
+					to: closer index + closer size - 1
+					withKind: opener type
+					withSubstring: correctSubstring).
+			"Delete openers above in stack, considered as unclosed so ignored"
+			self popFrom: 1 to: indexOfAssociateOpener
+		]
+]
+
+{ #category : #'class factory' }
 MicInlineSplitter >> allDelimiters [
 	^ allDelimiters
 ]
 
 { #category : #process }
-MicInlineSplitter >> delimiterFoundProcess: aDelimiterSubclass [
-	(aDelimiterSubclass type = #escape) 
-		ifTrue: [ incrementation := incrementation + 1 ]
-		ifFalse: [ delimiterStack add: (aDelimiterSubclass index: index) ]
+MicInlineSplitter >> bothCase [
+	openersStack 
+		ifEmpty: [ 
+			"It's the first opener"
+			self pushNewOpener
+		]
+		ifNotEmpty: [ 
+			(openersStack top type = delimiterSubclassFound type)
+			ifTrue: [ 
+				"We consider the delimiter as a closer of last opened inline block"
+				self addInlineBlock
+			 ]
+			ifFalse: [ 
+				"We consider the delimiter as a new opener"
+				self pushNewOpener
+			 ]
+		]
+	
 ]
 
-{ #category : #'class factory' }
-MicInlineSplitter >> emphasisProcessClass [
-	^ MicInlineEmphasisProcessor
+{ #category : #process }
+MicInlineSplitter >> closerOnlyCase [
+	"IF delimiter found is a closer which can close an opened inline block
+	THEN we add the associate inline block
+	ELSE we ignore it"
+	| indexOfAssociateOpener typesToFind|
+	typesToFind := (#(#linkName #figure) includes: delimiterSubclassFound type ) 
+		ifTrue: [#(#linkName #figure)] 
+		ifFalse: [ Array braceWith: delimiterSubclassFound type ].
+	indexOfAssociateOpener := openersStack findFirst: [ :opener | typesToFind includes: opener type ].
+	(indexOfAssociateOpener > 0) ifTrue: [ self addInlineBlock: indexOfAssociateOpener ]
+]
+
+{ #category : #process }
+MicInlineSplitter >> delimiterFoundProcess [
+	"Case 0: it's an escape character"
+	(delimiterSubclassFound type = #escape) 
+		ifTrue: [ incrementation := incrementation + 1 ]
+		ifFalse: [ 
+			"Case 1: it's a opener only"
+			(delimiterSubclassFound isOpenerOnly) 
+				ifTrue: [ self openerOnlyCase ]
+				ifFalse: [ 
+					"Case 2: it's both opener and closer"
+					(delimiterSubclassFound isBoth) 
+						ifTrue: [ self bothCase ]
+						ifFalse: [ 
+							"Case 3: it's a closer only"
+							self closerOnlyCase
+						]
+				]
+		]
+			
+			
+
 ]
 
 { #category : #accessing }
-MicInlineSplitter >> index [
-	^ index
-]
-
-{ #category : #actions }
 MicInlineSplitter >> indexIncrement [
 	^ self indexIncrement: 1
 ]
 
-{ #category : #actions }
+{ #category : #accessing }
 MicInlineSplitter >> indexIncrement: anInteger [
-	index := self index + anInteger
+	index := index + anInteger
 ]
 
-{ #category : #initialization }
+{ #category : #'class factory' }
 MicInlineSplitter >> initialize [
 	super initialize.
-	self initializeDelimiters
+	self initializeDelimiters.
+	openersStack := Stack new.
+	result := LinkedList new.
+	index := 1
 ]
 
-{ #category : #initialization }
+{ #category : #'class factory' }
 MicInlineSplitter >> initializeDelimiters [
 	allDelimiters := Dictionary new.
 	self abstractDelimiterClass subclasses 
@@ -99,33 +141,64 @@ MicInlineSplitter >> initializeDelimiters [
 ]
 
 { #category : #process }
-MicInlineSplitter >> linkOrImageProcess [
-	| linkNameCloserIndex |
-	"1. search the linkname closer delimiter"
-	linkNameCloserIndex := delimiterStack findLast: [ :delimiter | delimiter isOpener and: delimiter type = #linkName].
-]
-
-{ #category : #'as yet unclassified' }
-MicInlineSplitter >> pillarFrom: aString [
-	"return a collection of pillar nodes which can be used in setChildren: of the owner of aString"
-	^ (self start: aString) collect: [ :node | node asPillar ]
+MicInlineSplitter >> linkOrFigureProcess: indexOfAssociateOpener withOpener: opener withCloser: closer [
+	"IF we find a ( just after and a ) after again
+	THEN we add the associate link or figure inline block
+	ELSE we ignore it"
+	| startIndex endIndex urlCloserIndex correctSubstring correctURL |
+	((string allButFirst: (closer index + closer size - 1)) beginsWith: self urlOpenerDelimiterClass markup)
+		ifTrue: [ 
+			urlCloserIndex := string indexOfSubCollection: self urlCloserDelimiterClass markup startingAt: closer index ifAbsent: [ 0 ].
+			(urlCloserIndex > 0) 
+				ifTrue: [ 
+					startIndex := opener index + opener size.
+					endIndex := closer index - 1.
+					correctSubstring := string collect: [ :c | c ] from: startIndex to: endIndex.
+					correctURL := string collect: [ :c | c ] from: (closer index + closer size + self urlOpenerDelimiterClass size) to: (urlCloserIndex - 1).
+					"Add found inline block"
+					self halt.
+					result add: 
+						(opener associatedInlineBlock
+							from: opener index
+							to: urlCloserIndex 
+							withKind: opener type
+							withSubstring: correctSubstring
+							withURL: correctURL).
+				"Delete openers above in stack, considered as unclosed so ignored"
+				self popFrom: 1 to: indexOfAssociateOpener.
+				incrementation := urlCloserIndex - index
+				]
+				ifFalse: [ "do nothing" ]
+		]
+		ifFalse: [ "do nothing" ]
 ]
 
 { #category : #process }
-MicInlineSplitter >> processEmphasis [
-	resultArray := self emphasisProcessClass startWithStack: delimiterStack withString: string.
-	^ resultArray
+MicInlineSplitter >> openerOnlyCase [
+	self pushNewOpener
 ]
 
-{ #category : #actions }
+{ #category : #process }
+MicInlineSplitter >> popFrom: aStartIndex to: anEndIndex [
+	aStartIndex to: anEndIndex do: [ :i | openersStack pop ]
+	
+]
+
+{ #category : #process }
+MicInlineSplitter >> pushNewOpener [
+	openersStack push: (delimiterSubclassFound index: index)
+]
+
+{ #category : #'meta-object-protocol' }
 MicInlineSplitter >> read: aString [
 	incrementation := 1.
-	aString ifEmpty: [ ^ self processEmphasis ].
+	aString ifEmpty: [ "^ self resultProcess" ^ result ].
 	allDelimiters keys do: [ :key | 
  		(aString beginsWith: key) 
 			ifTrue: [ 
 				incrementation := key size.
-				self delimiterFoundProcess: (allDelimiters at: key).
+				delimiterSubclassFound := (allDelimiters at: key).
+				self delimiterFoundProcess
 			].
 	].
 	self indexIncrement: incrementation.
@@ -133,11 +206,18 @@ MicInlineSplitter >> read: aString [
 	
 ]
 
-{ #category : #public }
+{ #category : #accessing }
 MicInlineSplitter >> start: aString [
-	delimiterStack := Stack new.
-	resultArray := LinkedList new.
-	index := 1.
 	string := aString.
 	^ self read: aString
+]
+
+{ #category : #'class references' }
+MicInlineSplitter >> urlCloserDelimiterClass [
+	^ MicURLCloserDelimiter
+]
+
+{ #category : #'class references' }
+MicInlineSplitter >> urlOpenerDelimiterClass [
+	^ MicURLOpenerDelimiter 
 ]

--- a/src/Microdown/MicInlineSplitter.class.st
+++ b/src/Microdown/MicInlineSplitter.class.st
@@ -94,7 +94,7 @@ MicInlineSplitter >> closerOnlyCase [
 	typesToFind := (#(#linkName #figure) includes: delimiterSubclassFound type ) 
 		ifTrue: [#(#linkName #figure)] 
 		ifFalse: [ Array braceWith: delimiterSubclassFound type ].
-	indexOfAssociateOpener := openersStack findFirst: [ :opener | typesToFind includes: opener type ].
+	indexOfAssociateOpener := openersStack findFirst: [ :each | typesToFind includes: each type ].
 	(indexOfAssociateOpener > 0) ifTrue: [ self addInlineBlock: indexOfAssociateOpener ]
 ]
 

--- a/src/Microdown/MicInlineSplitterOld.class.st
+++ b/src/Microdown/MicInlineSplitterOld.class.st
@@ -1,0 +1,143 @@
+"
+I represent the class which is in charge of splitting sentences to parse inline blocks.
+
+To proceed: `MicInlineSplitter new start: stringToParse`
+
+### Implementation: How parsing is made ? 
+- Read the string to parse and memorize all delimiters we meet in a collection
+- Start the `emphasisProcess`
+   - Search for the first opener delimiter in collection
+   - If it’s a link or a figure opener delimiter, start the `linkOrFigureProcess`
+     - Search for the associate closer
+     - Search for the following url
+     - Add it to the final array of inlines blocks
+   - Search for the associate closer
+   - Check if we have nested inline blocks (like bold in italic format)
+   - Add the found inline block to the final array of inlines blocks
+
+Note1: the escape delimiter is `\` (back slash)
+Note2: a new line in an inline paragraph doesn’t interfere with parsing. 
+The following example is totally bold:
+```
+		**Hello
+		world**
+```
+Note3: BUT a line between two lines must end the parsing process.
+The following example must not be bold:
+
+```
+		**Hello
+
+		world**
+```
+"
+Class {
+	#name : #MicInlineSplitterOld,
+	#superclass : #Object,
+	#instVars : [
+		'string',
+		'resultArray',
+		'index',
+		'delimiterStack',
+		'allDelimiters',
+		'incrementation'
+	],
+	#category : #'Microdown-Parser'
+}
+
+{ #category : #'class factory' }
+MicInlineSplitterOld >> abstractDelimiterClass [
+	^ MicAbstractDelimiter
+]
+
+{ #category : #accessing }
+MicInlineSplitterOld >> allDelimiters [
+	^ allDelimiters
+]
+
+{ #category : #process }
+MicInlineSplitterOld >> delimiterFoundProcess: aDelimiterSubclass [
+	(aDelimiterSubclass type = #escape) 
+		ifTrue: [ incrementation := incrementation + 1 ]
+		ifFalse: [ delimiterStack add: (aDelimiterSubclass index: index) ]
+]
+
+{ #category : #'class factory' }
+MicInlineSplitterOld >> emphasisProcessClass [
+	^ MicInlineEmphasisProcessor
+]
+
+{ #category : #accessing }
+MicInlineSplitterOld >> index [
+	^ index
+]
+
+{ #category : #actions }
+MicInlineSplitterOld >> indexIncrement [
+	^ self indexIncrement: 1
+]
+
+{ #category : #actions }
+MicInlineSplitterOld >> indexIncrement: anInteger [
+	index := self index + anInteger
+]
+
+{ #category : #initialization }
+MicInlineSplitterOld >> initialize [
+	super initialize.
+	self initializeDelimiters
+]
+
+{ #category : #initialization }
+MicInlineSplitterOld >> initializeDelimiters [
+	allDelimiters := Dictionary new.
+	self abstractDelimiterClass subclasses 
+		select: [ :subclass | subclass isActive ]
+		thenDo: [ :subclass | allDelimiters 
+										at: subclass markup 
+										put: subclass ]
+]
+
+{ #category : #process }
+MicInlineSplitterOld >> linkOrImageProcess [
+	| linkNameCloserIndex |
+	"1. search the linkname closer delimiter"
+	linkNameCloserIndex := delimiterStack findLast: [ :delimiter | delimiter isOpener and: delimiter type = #linkName].
+]
+
+{ #category : #'as yet unclassified' }
+MicInlineSplitterOld >> pillarFrom: aString [
+	"return a collection of pillar nodes which can be used in setChildren: of the owner of aString"
+	^ (self start: aString) collect: [ :node | node asPillar ]
+]
+
+{ #category : #process }
+MicInlineSplitterOld >> processEmphasis [
+	resultArray := self emphasisProcessClass startWithStack: delimiterStack withString: string.
+	^ resultArray
+]
+
+{ #category : #actions }
+MicInlineSplitterOld >> read: aString [
+	incrementation := 1.
+	aString ifEmpty: [ ^ self processEmphasis ].
+	allDelimiters keys do: [ :key | 
+ 		(aString beginsWith: key) 
+			ifTrue: [ 
+				incrementation := key size.
+				self delimiterFoundProcess: (allDelimiters at: key).
+			].
+	].
+	self indexIncrement: incrementation.
+	^ self read: (aString allButFirst: incrementation)
+	
+]
+
+{ #category : #public }
+MicInlineSplitterOld >> start: aString [
+	delimiterStack := Stack new.
+	resultArray := LinkedList new.
+	index := 1.
+	string := aString.
+	^ self read: aString
+]


### PR DESCRIPTION
Just one fail for escaped formats in links like `[**name**](url)`

Now I use an openers stack and handle one delimiter after one another