### PR TITLE
A pass on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ Under writing...
 Similar to markdonw headers are composed of `#` space text on one line.
 The headers can be from 1 to 6
 
-```
+~~~Markdown
 ### Header Level3
-```
+~~~
 There is not support for other forms of declaration. 
 
 ### Anchors
@@ -98,18 +98,18 @@ Microdown offer the same code block that markdown but arguments can be specified
 
 The following code is not able to display it because markdown quote block are strange and interpret nested block. So we cannot use quoteblock for quoting!
 
-``` 
-   ```language=pharo|label=code1|caption=this is my great piece of code
-    codeBlockMarkupString
-    ^ '```'
-    ```
+~~~Markdown 
+```language=pharo|label=code1|caption=this is my great piece of code
+codeBlockMarkupString
+^ '```'
 ```
-````
+~~~
+~~~Markdown
 ```language=pharo|label=code1|caption=this is my great piece of code
 codeBlockMarkupString
    ^ '\`\`\`'
 ```
-````
+~~~
 
 More to come...
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,28 @@ But also
 
 ![Microdown within the Pharo IDE.](screen.png)
 
+## How to install it?
+
+To install `Microdown`, go to the Playground (Ctrl+OW) in your [Pharo](https://pharo.org/) image and execute the following Metacello script (select it and press Do-it button or Ctrl+D):
+
+```Smalltalk
+Metacello new
+  baseline: 'Microdown';
+  repository: 'github://pillar-markup/Microdown/src';
+  load.
+```
+
+## How to depend on it?
+
+If you want to add a dependency on `Microdown` to your project, include the following lines into your baseline method:
+
+```Smalltalk
+spec
+  baseline: 'Microdown'
+  with: [ spec repository: 'github://pillar-markup/Microdown/src' ].
+```
+
+If you are new to baselines and Metacello, check out the [Baselines](https://github.com/pharo-open-documentation/pharo-wiki/blob/master/General/Baselines.md) tutorial on Pharo Wiki.
 
 ## Core Syntax in 2 seconds
 
@@ -115,14 +137,5 @@ When a new line is read we do the following:
 
 The other packages in this repository are the extensions made to produce Pillar model. 
 Such packages should be moved in the future to other location (probably pillar itself).
-
-## Loading
-
-```
-Metacello new
-  baseline: 'Microdown';
-  repository: 'github://pillar-markup/Microdown/src';
-  load.
-```
 
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you are new to baselines and Metacello, check out the [Baselines](https://git
 ```Markdown
 #Header
 
-`` ``` ``language=Pharo&caption=Beautiful&label=Fig1
+` ``` `language=Pharo&caption=Beautiful&label=Fig1
 code
 `` ``` ``
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ code
 `Point`, `Point class`, `Point>>#setX:setY:`, `#’Microdown-Tests’ (for packages)
 
 References: *@ref*
+
+Math: $ a^2 + b^2 = c^2 $
 ~~~
 
 ## Full Syntax

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ If you are new to baselines and Metacello, check out the [Baselines](https://git
 ```Markdown
 #Header
 
-` ``` `language=Pharo&caption=Beautiful&label=Fig1
+ ```language=Pharo&caption=Beautiful&label=Fig1
 code
-`` ``` ``
+ ```
 
 > Boring quote block 
 > Don't use me!

--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ If you are new to baselines and Metacello, check out the [Baselines](https://git
 
 ## Core Syntax in 2 seconds
 
-```Markdown
+~~~Markdown
 #Header
 
- ```language=Pharo&caption=Beautiful&label=Fig1
+```language=Pharo&caption=Beautiful&label=Fig1
 code
- ```
+```
 
 > Boring quote block 
 > Don't use me!
@@ -70,7 +70,7 @@ code
 `Point`, `Point class`, `Point>>#setX:setY:`, `#’Microdown-Tests’ (for packages)
 
 References: *@ref*
-```
+~~~
 
 ## Full Syntax
 Under writing...

--- a/README.md
+++ b/README.md
@@ -51,25 +51,25 @@ If you are new to baselines and Metacello, check out the [Baselines](https://git
 
 ## Core Syntax in 2 seconds
 
-```
-   	#Header
+```Markdown
+#Header
 
-	```language=Pharo&caption=Beautiful&label=Fig1
-   	code
-	```
-   
-   	> Boring quote block 
-   	> Don't use me!
+`` ``` ``language=Pharo&caption=Beautiful&label=Fig1
+code
+`` ``` ``
 
-   	![Pharo is cool](http://pharo.org)
-	
-   	- list
-   	1. ordered list 
+> Boring quote block 
+> Don't use me!
 
-  	`in text` and for Pharo hyperlinks to class, method and package: 
-  	`Point`, `Point class`, `Point>>#setX:setY:`, `#’Microdown-Tests’ (for packages)
+![Pharo is cool](http://pharo.org)
 
-  	References: *@ref*
+- list
+1. ordered list 
+
+`in text` and for Pharo hyperlinks to class, method and package: 
+`Point`, `Point class`, `Point>>#setX:setY:`, `#’Microdown-Tests’ (for packages)
+
+References: *@ref*
 ```
 
 ## Full Syntax


### PR DESCRIPTION
Moved Metacello script to the top, added instructions on how to depend on Microdown using baselines, and fixed the code highlighting