### PR TITLE
Fix dependencies so microdown-pillar can be loaded without 

### DIFF
--- a/src/BaselineOfMicrodown/BaselineOfMicrodown.class.st
+++ b/src/BaselineOfMicrodown/BaselineOfMicrodown.class.st
@@ -39,6 +39,6 @@ BaselineOfMicrodown >> pillar: spec [
 	spec project: 'PillarModel' copyFrom: 'Pillar' with: [ 
 			spec loads: #('Pillar-Model') ].
 	
-	spec project: 'PillarRichTextComposer' with: [ 
+	spec project: 'PillarRichTextComposer' copyFrom: 'Pillar' with: [ 
 			spec loads: #('rich text exporter') ].
 ]

--- a/src/BaselineOfMicrodown/BaselineOfMicrodown.class.st
+++ b/src/BaselineOfMicrodown/BaselineOfMicrodown.class.st
@@ -13,22 +13,32 @@ BaselineOfMicrodown >> baseline: spec [
 	<baseline>
 	
 	spec for: #'common' do: [
-		spec baseline: 'Pillar' with: [ spec 
-				loads: #('rich text exporter');
-				repository: 'github://pillar-markup/pillar:dev-8/src' ].
+		self pillar: spec.
 		spec 
 			package: #'Microdown';
 			package: #'Microdown-Tests'  with: [
 				spec requires:  #( #'Microdown') ];
 			
 			package: #'Microdown-Pillar' with: [
-				spec requires:  #( #'Microdown' 'Pillar') ];
+				spec requires:  #( #'Microdown' 'PillarModel') ];
 			package: #'Microdown-Pillar-Tests' with: [
 				spec requires:  #(#'Microdown-Pillar' #'Microdown-Tests') ];
 			package: #'Microdown-Calypso' with: [
 				spec requires:  #(#'Microdown-Pillar' 'Microdown-RichTextComposer') ];
 			package: #'Microdown-RichTextComposer' with: [
-				spec requires:  #('Microdown' #'Microdown-Pillar') ]
+				spec requires:  #('Microdown' #'Microdown-Pillar' 'PillarRichTextComposer' ) ]
 			]
 
+]
+
+{ #category : #baselines }
+BaselineOfMicrodown >> pillar: spec [
+	spec baseline: 'Pillar' with: [ 
+		spec repository: 'github://pillar-markup/pillar:dev-8/src' ].
+	
+	spec project: 'PillarModel' copyFrom: 'Pillar' with: [ 
+			spec loads: #('Pillar-Model') ].
+	
+	spec project: 'PillarRichTextComposer' with: [ 
+			spec loads: #('rich text exporter') ].
 ]


### PR DESCRIPTION
rich text composer. Dependencies are too broad to make microdown useful on its own. Reduced number of dependencies