### PR TITLE
Loading script from README doesn't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Such packages should be moved in the future to other location (probably pillar i
 ```
 Metacello new
   baseline: 'Microdown';
-  repository: 'github://pillar-markup/Microdown/src';
+  repository: 'github://pillar-markup/Microdown:dev';
   load.
 ```
 

--- a/src/BaselineOfMicrodown/BaselineOfMicrodown.class.st
+++ b/src/BaselineOfMicrodown/BaselineOfMicrodown.class.st
@@ -14,7 +14,7 @@ BaselineOfMicrodown >> baseline: spec [
 	
 	spec for: #'common' do: [
 		spec baseline: 'PillarDocumentModel' with: [ spec 
-				repository: 'github://pillar-markup/pillar:v8.0.12/src' ].
+				repository: 'github://pillar-markup/pillar:dev-8' ].
 		spec 
 			package: #'Microdown';
 			package: #'Microdown-Tests' with: [ spec requires:  #( #'Microdown') ];


### PR DESCRIPTION
Hi!
The Metacello load script in the README does not work. I see 2 causes:
1. The branch 'master' no longer exists, which causes a 'Revspec master not found' error.
2. The Microdown baseline contains a dependency on baseline PillarDocumentModel using git tag v8.0.12, which doesn't contain this baseline class.

I just noticed there is a BaselineOfMicrodownDev class, which solves problem 2. However, this is not mentioned in the README. 

Nice work by the way!

Kind regards,
Jonathan