### PR TITLE
markup annotation

### DIFF
--- a/src/Microdown-PrettyPrinter-Tests/MicDumperTest.class.st
+++ b/src/Microdown-PrettyPrinter-Tests/MicDumperTest.class.st
@@ -120,7 +120,7 @@ MicDumperTest >> testPrintMicAnnotated [
 MicDumperTest >> testPrintMicAnnotationBlock [
 	| micAnnotation |
 	micAnnotation := (parser parse: factory annotationSample) children first children second.
-	self assert: (micAnnotation accept: visitor) equals: 'MicAnnotationBlock " Foo | value=aFoo&label=42 "'
+	self assert: (micAnnotation accept: visitor) equals: 'MicAnnotationBlock "Foo | value=aFoo&label=42 "'
 ]
 
 { #category : #'tests-inline block' }

--- a/src/Microdown-Tests/MicInlineParserTest.class.st
+++ b/src/Microdown-Tests/MicInlineParserTest.class.st
@@ -42,10 +42,10 @@ MicInlineParserTest >> testAnnotationWithParameters [
 
 	| res |
 	res := self splitter parse:
-		       'abc<<an annotation|key=cite&label=42>>def'.
+		       'abc',MicAnnotationOpenerDelimiter markup,'an annotation|key=cite&label=42',MicAnnotationCloserDelimiter markup,'def'.
 	self
 		assert: (res collect: [ :x | x printString ])
-		equals: { 'abc'. '<<an annotation|key=cite&label=42>>'.
+		equals: { 'abc'. MicAnnotationOpenerDelimiter markup,'an annotation|key=cite&label=42', MicAnnotationCloserDelimiter markup.
 			'def' }.
 	self assert: (res second isKindOf: MicAnnotationBlock).
 	self assert: (res second arguments at: 'key') equals: 'cite'.
@@ -56,10 +56,10 @@ MicInlineParserTest >> testAnnotationWithParameters [
 MicInlineParserTest >> testAnnotationWithParametersWithBlank [
 
 	| res |
-	res := self splitter parse: 'abc<<an annotation|key=&label=42>>def'.
+	res := self splitter parse: 'abc',MicAnnotationOpenerDelimiter markup,'an annotation|key=&label=42',MicAnnotationCloserDelimiter markup,'def'.
 	self
 		assert: (res collect: [ :x | x printString ])
-		equals: { 'abc'. '<<an annotation|key=&label=42>>'.
+		equals: { 'abc'. MicAnnotationOpenerDelimiter markup,'an annotation|key=&label=42',MicAnnotationCloserDelimiter markup.
 			'def' }.
 	self assert: (res second isKindOf: MicAnnotationBlock).
 	self assert: (res second arguments at: 'key') equals: ''.
@@ -508,10 +508,10 @@ MicInlineParserTest >> testSplitAnnotation [
 
 	| res |
 	res := self splitter parse:
-		       'abc<<type:value|key1=val1&key2=val2>>def'.
+		       'abc',MicAnnotationOpenerDelimiter markup,'type:value|key1=val1&key2=val2',MicAnnotationCloserDelimiter markup,'def'.
 	self
 		assert: (res collect: [ :x | x printString ])
-		equals: { 'abc'. '<<type:value|key1=val1&key2=val2>>'.
+		equals: { 'abc'. MicAnnotationOpenerDelimiter markup,'type:value|key1=val1&key2=val2',MicAnnotationCloserDelimiter markup.
 			'def' }
 ]
 
@@ -519,10 +519,10 @@ MicInlineParserTest >> testSplitAnnotation [
 MicInlineParserTest >> testSplitBlockAnnotation [
 
 	| res |
-	res := self splitter parse: 'abc<<an annotation>>def'.
+	res := self splitter parse: 'abc',MicAnnotationOpenerDelimiter markup,'an annotation',MicAnnotationCloserDelimiter markup,'def'.
 	self
 		assert: (res collect: [ :x | x printString ])
-		equals: { 'abc'. '<<an annotation>>'. 'def' }.
+		equals: { 'abc'. MicAnnotationOpenerDelimiter markup,'an annotation',MicAnnotationCloserDelimiter markup. 'def' }.
 	self assert: (res second isKindOf: MicAnnotationBlock)
 ]
 

--- a/src/Microdown-Tests/MicInlineParserTest.class.st
+++ b/src/Microdown-Tests/MicInlineParserTest.class.st
@@ -42,10 +42,10 @@ MicInlineParserTest >> testAnnotationWithParameters [
 
 	| res |
 	res := self splitter parse:
-		       'abc<?an annotation|key=cite&label=42?>def'.
+		       'abc<<an annotation|key=cite&label=42>>def'.
 	self
 		assert: (res collect: [ :x | x printString ])
-		equals: { 'abc'. '<?an annotation|key=cite&label=42?>'.
+		equals: { 'abc'. '<<an annotation|key=cite&label=42>>'.
 			'def' }.
 	self assert: (res second isKindOf: MicAnnotationBlock).
 	self assert: (res second arguments at: 'key') equals: 'cite'.
@@ -56,10 +56,10 @@ MicInlineParserTest >> testAnnotationWithParameters [
 MicInlineParserTest >> testAnnotationWithParametersWithBlank [
 
 	| res |
-	res := self splitter parse: 'abc<?an annotation|key=&label=42?>def'.
+	res := self splitter parse: 'abc<<an annotation|key=&label=42>>def'.
 	self
 		assert: (res collect: [ :x | x printString ])
-		equals: { 'abc'. '<?an annotation|key=&label=42?>'.
+		equals: { 'abc'. '<<an annotation|key=&label=42>>'.
 			'def' }.
 	self assert: (res second isKindOf: MicAnnotationBlock).
 	self assert: (res second arguments at: 'key') equals: ''.
@@ -508,10 +508,10 @@ MicInlineParserTest >> testSplitAnnotation [
 
 	| res |
 	res := self splitter parse:
-		       'abc<?type:value|key1=val1&key2=val2?>def'.
+		       'abc<<type:value|key1=val1&key2=val2>>def'.
 	self
 		assert: (res collect: [ :x | x printString ])
-		equals: { 'abc'. '<?type:value|key1=val1&key2=val2?>'.
+		equals: { 'abc'. '<<type:value|key1=val1&key2=val2>>'.
 			'def' }
 ]
 
@@ -519,10 +519,10 @@ MicInlineParserTest >> testSplitAnnotation [
 MicInlineParserTest >> testSplitBlockAnnotation [
 
 	| res |
-	res := self splitter parse: 'abc<?an annotation?>def'.
+	res := self splitter parse: 'abc<<an annotation>>def'.
 	self
 		assert: (res collect: [ :x | x printString ])
-		equals: { 'abc'. '<?an annotation?>'. 'def' }.
+		equals: { 'abc'. '<<an annotation>>'. 'def' }.
 	self assert: (res second isKindOf: MicAnnotationBlock)
 ]
 

--- a/src/Microdown-Tests/MicMicroDownSnippetFactory.class.st
+++ b/src/Microdown-Tests/MicMicroDownSnippetFactory.class.st
@@ -46,7 +46,7 @@ Foo _bar_
 MicMicrodownSnippetFactory >> annotationSample [
 
 	^ '
-abc<< Foo | value=aFoo&label=42 >>def
+abc', MicAnnotationOpenerDelimiter markup , 'Foo | value=aFoo&label=42 ', MicAnnotationCloserDelimiter markup ,'def
 '
 ]
 

--- a/src/Microdown-Tests/MicMicroDownSnippetFactory.class.st
+++ b/src/Microdown-Tests/MicMicroDownSnippetFactory.class.st
@@ -44,8 +44,9 @@ Foo _bar_
 
 { #category : #annotations }
 MicMicrodownSnippetFactory >> annotationSample [
+
 	^ '
-abc<? Foo | value=aFoo&label=42 ?>def
+abc<< Foo | value=aFoo&label=42 >>def
 '
 ]
 

--- a/src/Microdown-Tests/MicMicrodownTextualBuilderTest.class.st
+++ b/src/Microdown-Tests/MicMicrodownTextualBuilderTest.class.st
@@ -55,7 +55,7 @@ MicMicrodownTextualBuilderTest >> testAnnotation [
 
 	self 
 		assert: (builder annotation: 'anAnnotationName' arguments: {'label'->'aLabel' . 'value' -> '42'} asDictionary) contents 
-		equals: '<< anAnnotationName | label=aLabel&value=42>>'
+		equals: MicAnnotationOpenerDelimiter markup,' anAnnotationName | label=aLabel&value=42',MicAnnotationCloserDelimiter markup
 ]
 
 { #category : #'tests - anchor' }
@@ -63,7 +63,7 @@ MicMicrodownTextualBuilderTest >> testAnnotationNoArgs [
 
 	self 
 		assert: (builder annotation: 'anAnnotationName' arguments: {} ) contents 
-		equals: '<< anAnnotationName>>'
+		equals: MicAnnotationOpenerDelimiter markup,' anAnnotationName',MicAnnotationCloserDelimiter markup
 ]
 
 { #category : #'tests - format' }

--- a/src/Microdown-Tests/MicMicrodownTextualBuilderTest.class.st
+++ b/src/Microdown-Tests/MicMicrodownTextualBuilderTest.class.st
@@ -55,7 +55,7 @@ MicMicrodownTextualBuilderTest >> testAnnotation [
 
 	self 
 		assert: (builder annotation: 'anAnnotationName' arguments: {'label'->'aLabel' . 'value' -> '42'} asDictionary) contents 
-		equals: '<? anAnnotationName | label=aLabel&value=42?>'
+		equals: '<< anAnnotationName | label=aLabel&value=42>>'
 ]
 
 { #category : #'tests - anchor' }
@@ -63,7 +63,7 @@ MicMicrodownTextualBuilderTest >> testAnnotationNoArgs [
 
 	self 
 		assert: (builder annotation: 'anAnnotationName' arguments: {} ) contents 
-		equals: '<? anAnnotationName?>'
+		equals: '<< anAnnotationName>>'
 ]
 
 { #category : #'tests - format' }

--- a/src/Microdown-Tests/MicMicrodownTextualBuilderTest.class.st
+++ b/src/Microdown-Tests/MicMicrodownTextualBuilderTest.class.st
@@ -55,7 +55,7 @@ MicMicrodownTextualBuilderTest >> testAnnotation [
 
 	self 
 		assert: (builder annotation: 'anAnnotationName' arguments: {'label'->'aLabel' . 'value' -> '42'} asDictionary) contents 
-		equals: MicAnnotationOpenerDelimiter markup,' anAnnotationName | label=aLabel&value=42',MicAnnotationCloserDelimiter markup
+		equals: MicAnnotationOpenerDelimiter markup,'anAnnotationName | label=aLabel&value=42',MicAnnotationCloserDelimiter markup
 ]
 
 { #category : #'tests - anchor' }
@@ -63,7 +63,7 @@ MicMicrodownTextualBuilderTest >> testAnnotationNoArgs [
 
 	self 
 		assert: (builder annotation: 'anAnnotationName' arguments: {} ) contents 
-		equals: MicAnnotationOpenerDelimiter markup,' anAnnotationName',MicAnnotationCloserDelimiter markup
+		equals: MicAnnotationOpenerDelimiter markup,'anAnnotationName',MicAnnotationCloserDelimiter markup
 ]
 
 { #category : #'tests - format' }

--- a/src/Microdown-Tests/MicroDownInlineParserTest.class.st
+++ b/src/Microdown-Tests/MicroDownInlineParserTest.class.st
@@ -98,8 +98,8 @@ MicrodownInlineParserTest >> testAnnotationBasic [
  	self assert: annotation substring equals: 'footnote | value=A foonote is annotation.'.
 	
  	self assert: annotation kind equals: 'annotation'.
- 	self assert: annotation openingDelimiter equals: '<<'.
- 	self assert: annotation closingDelimiter equals: '>>'
+ 	self assert: annotation openingDelimiter equals: MicAnnotationOpenerDelimiter markup.
+ 	self assert: annotation closingDelimiter equals: MicAnnotationCloserDelimiter markup
  
 ]
 
@@ -107,7 +107,7 @@ MicrodownInlineParserTest >> testAnnotationBasic [
 MicrodownInlineParserTest >> testAnnotationPrintString [
  	
 	| elements |
- 	elements := self parseAndReturnElementsOfParagraphFor: 'abc<<footnote | value=A foonote is annotation.&width=90>>def'.
+ 	elements := self parseAndReturnElementsOfParagraphFor: 'abc',MicAnnotationOpenerDelimiter markup,'footnote | value=A foonote is annotation.&width=90',MicAnnotationCloserDelimiter markup,'def'.
  	self assert: elements size equals: 3.
  	self assert: elements second text equals: 'footnote | value=A foonote is annotation.&width=90'.
 	self assert: elements second name equals: 'footnote'.
@@ -117,13 +117,13 @@ MicrodownInlineParserTest >> testAnnotationPrintString [
 { #category : #'tests - annotations' }
 MicrodownInlineParserTest >> testAnnotations [
  	| elements |
- 	elements := self parseAndReturnElementsOfParagraphFor: 'abc<<footnote | value=A foonote is annotation.>>def'.
+ 	elements := self parseAndReturnElementsOfParagraphFor: 'abc',MicAnnotationOpenerDelimiter markup,'footnote | value=A foonote is annotation.',MicAnnotationCloserDelimiter markup,'def'.
  	self assert: elements size equals: 3.
  	self assert: elements first substring equals: 'abc'.
  	self assert: elements second substring equals: 'footnote | value=A foonote is annotation.'.
  	self assert: elements second kind equals: 'annotation'.
- 	self assert: elements second openingDelimiter equals: '<<'.
- 	self assert: elements second closingDelimiter equals: '>>'
+ 	self assert: elements second openingDelimiter equals: MicAnnotationOpenerDelimiter markup.
+ 	self assert: elements second closingDelimiter equals: MicAnnotationCloserDelimiter markup
  
 ]
 

--- a/src/Microdown-Tests/MicroDownInlineParserTest.class.st
+++ b/src/Microdown-Tests/MicroDownInlineParserTest.class.st
@@ -91,15 +91,15 @@ MicrodownInlineParserTest >> testAnchorRefernce [
 { #category : #'tests - annotations' }
 MicrodownInlineParserTest >> testAnnotationBasic [
  	| elements annotation |
- 	elements := self parseAndReturnElementsOfParagraphFor: 'needed <?footnote | value=A foonote is annotation.?>'.
+ 	elements := self parseAndReturnElementsOfParagraphFor: 'needed ', MicAnnotationOpenerDelimiter markup ,'footnote | value=A foonote is annotation.', MicAnnotationCloserDelimiter markup.
 	"pay attention an annotation is inside a paragraph (else this is an environment)"
 	annotation := elements second.
 	
  	self assert: annotation substring equals: 'footnote | value=A foonote is annotation.'.
 	
  	self assert: annotation kind equals: 'annotation'.
- 	self assert: annotation openingDelimiter equals: '<?'.
- 	self assert: annotation closingDelimiter equals: '?>'
+ 	self assert: annotation openingDelimiter equals: '<<'.
+ 	self assert: annotation closingDelimiter equals: '>>'
  
 ]
 
@@ -107,7 +107,7 @@ MicrodownInlineParserTest >> testAnnotationBasic [
 MicrodownInlineParserTest >> testAnnotationPrintString [
  	
 	| elements |
- 	elements := self parseAndReturnElementsOfParagraphFor: 'abc<?footnote | value=A foonote is annotation.&width=90?>def'.
+ 	elements := self parseAndReturnElementsOfParagraphFor: 'abc<<footnote | value=A foonote is annotation.&width=90>>def'.
  	self assert: elements size equals: 3.
  	self assert: elements second text equals: 'footnote | value=A foonote is annotation.&width=90'.
 	self assert: elements second name equals: 'footnote'.
@@ -117,13 +117,13 @@ MicrodownInlineParserTest >> testAnnotationPrintString [
 { #category : #'tests - annotations' }
 MicrodownInlineParserTest >> testAnnotations [
  	| elements |
- 	elements := self parseAndReturnElementsOfParagraphFor: 'abc<?footnote | value=A foonote is annotation.?>def'.
+ 	elements := self parseAndReturnElementsOfParagraphFor: 'abc<<footnote | value=A foonote is annotation.>>def'.
  	self assert: elements size equals: 3.
  	self assert: elements first substring equals: 'abc'.
  	self assert: elements second substring equals: 'footnote | value=A foonote is annotation.'.
  	self assert: elements second kind equals: 'annotation'.
- 	self assert: elements second openingDelimiter equals: '<?'.
- 	self assert: elements second closingDelimiter equals: '?>'
+ 	self assert: elements second openingDelimiter equals: '<<'.
+ 	self assert: elements second closingDelimiter equals: '>>'
  
 ]
 
@@ -475,7 +475,7 @@ MicrodownInlineParserTest >> testStructureOfAnchorReference [
 MicrodownInlineParserTest >> testStructureOfAnnotation [
 
  	| element |
- 	element := (self parseAndReturnElementsOfParagraphFor: '  <?annotation?>') first.
+ 	element := (self parseAndReturnElementsOfParagraphFor: MicAnnotationOpenerDelimiter markup , 'annotation' , MicAnnotationCloserDelimiter markup ) first.
 	self assert: element text equals: 'annotation'.
 	self assert: element name equals: 'annotation'.
 	self assert: element children equals: #()
@@ -486,7 +486,7 @@ MicrodownInlineParserTest >> testStructureOfAnnotation [
 MicrodownInlineParserTest >> testStructureOfAnnotationWithParameters [
 
  	| element |
- 	element := (self parseAndReturnElementsOfParagraphFor: '  <?inputFile|path=PharoTour.mic?>') first.
+ 	element := (self parseAndReturnElementsOfParagraphFor: MicAnnotationOpenerDelimiter markup , 'inputFile|path=PharoTour.mic' , MicAnnotationCloserDelimiter markup ) first.
 	self assert: element name equals: 'inputFile'.
 	self assert: element children equals: #().
 	self assert: element text equals: 'inputFile|path=PharoTour.mic'.

--- a/src/Microdown/MicAnnotationCloserDelimiter.class.st
+++ b/src/Microdown/MicAnnotationCloserDelimiter.class.st
@@ -28,7 +28,8 @@ MicAnnotationCloserDelimiter class >> isOpener [
 
 { #category : #accessing }
 MicAnnotationCloserDelimiter class >> markup [
-	^ '?>'
+
+	^ '>>'
 ]
 
 { #category : #accessing }

--- a/src/Microdown/MicAnnotationCloserDelimiter.class.st
+++ b/src/Microdown/MicAnnotationCloserDelimiter.class.st
@@ -29,7 +29,7 @@ MicAnnotationCloserDelimiter class >> isOpener [
 { #category : #accessing }
 MicAnnotationCloserDelimiter class >> markup [
 
-	^ '>>'
+	^ '}?'
 ]
 
 { #category : #accessing }

--- a/src/Microdown/MicAnnotationOpenerDelimiter.class.st
+++ b/src/Microdown/MicAnnotationOpenerDelimiter.class.st
@@ -21,7 +21,8 @@ MicAnnotationOpenerDelimiter class >> isOpener [
 
 { #category : #accessing }
 MicAnnotationOpenerDelimiter class >> markup [
-	^ '<?'
+
+	^ '<<'
 ]
 
 { #category : #accessing }

--- a/src/Microdown/MicAnnotationOpenerDelimiter.class.st
+++ b/src/Microdown/MicAnnotationOpenerDelimiter.class.st
@@ -22,7 +22,7 @@ MicAnnotationOpenerDelimiter class >> isOpener [
 { #category : #accessing }
 MicAnnotationOpenerDelimiter class >> markup [
 
-	^ '<<'
+	^ '?{'
 ]
 
 { #category : #accessing }

--- a/src/Microdown/MicMicrodownTextualBuilder.class.st
+++ b/src/Microdown/MicMicrodownTextualBuilder.class.st
@@ -66,18 +66,15 @@ MicMicrodownTextualBuilder >> annotatedAnnotation: annotation [
 MicMicrodownTextualBuilder >> annotation: aString arguments: aDictionary [
 
 	self raw: MicAnnotationOpenerDelimiter markup.
-	self space.
 	self raw: aString.
-	aDictionary ifNotEmpty: [ self raw: ' | '.
-		aDictionary 
-			keysAndValuesDo: [ :key :value | 
-				self raw: key.
-				self raw: '='.
-				self raw: value.
-				key = aDictionary keys last
-					ifFalse: [ self raw: '&' ]	]	
-		 ].
-	self raw: MicAnnotationCloserDelimiter markup.
+	aDictionary ifNotEmpty: [ 
+		self raw: ' | '.
+		aDictionary keysAndValuesDo: [ :key :value | 
+			self raw: key.
+			self raw: '='.
+			self raw: value.
+			key = aDictionary keys last ifFalse: [ self raw: '&' ] ] ].
+	self raw: MicAnnotationCloserDelimiter markup
 ]
 
 { #category : #'element - format' }

--- a/src/Microdown/MicStartStopMarkupBlock.class.st
+++ b/src/Microdown/MicStartStopMarkupBlock.class.st
@@ -81,10 +81,9 @@ MicStartStopMarkupBlock >> doesLineStartWithMarkup: line [
 
 { #category : #testing }
 MicStartStopMarkupBlock >> doesLineStartWithStopMarkup: line [
-	"return if the line starts with a stop markup"
 
+	"return if the line starts with a stop markup"
 	^ line beginsWith: self lineStopMarkup
-	
 ]
 
 { #category : #handle }


### PR DESCRIPTION
change markup of annotation by ?{ }? et fix tests to work if we change markup later.

I use ?{ instead of {? because with {? the parser give a MetaDataBlock.