### PR TITLE
Resolve path of figure

### DIFF
--- a/src/Microdown-MicrodownRichTextComposer/MicRichTextComposer.class.st
+++ b/src/Microdown-MicrodownRichTextComposer/MicRichTextComposer.class.st
@@ -721,7 +721,7 @@ MicRichTextComposer >> visitFigure: aFigure [
 	anchoredImage := url scheme = 'file'
 		                 ifTrue: [ 
 								  self flag: 'fix url host'.
-			                 aFigure currentSystem / (url host ,'/', url path)
+			                 aFigure originPath fileSystem / (url path)
 				                 binaryReadStreamDo: [ :stream | 
 				                 ImageReadWriter formFromStream: stream ] ]
 		                 ifFalse: [ self cachedImageFromUrl: url ].

--- a/src/Microdown-MicrodownRichTextComposer/MicRichTextComposer.class.st
+++ b/src/Microdown-MicrodownRichTextComposer/MicRichTextComposer.class.st
@@ -587,7 +587,8 @@ MicRichTextComposer >> renderMathExpression: aString [
 MicRichTextComposer >> resizeImage: anImage of: aFigure [
 
 	| anchoredImage |
-	aFigure arguments at: #size ifPresent: [ :s | 
+	anchoredImage := anImage.
+	aFigure arguments at: #width ifPresent: [ :s | 
 		anchoredImage := anImage scaledToSize: s asNumber @ s asNumber ].
 	^ anchoredImage
 ]

--- a/src/Microdown-MicrodownRichTextComposer/MicRichTextComposer.class.st
+++ b/src/Microdown-MicrodownRichTextComposer/MicRichTextComposer.class.st
@@ -712,24 +712,29 @@ MicRichTextComposer >> visitEnvironment: anObject [
 
 { #category : #'visiting - inline elements' }
 MicRichTextComposer >> visitFigure: aFigure [
-
 	"Try to read a png file (only one supported right now), else use alt text"
-
+	aFigure isImageFile ifTrue: [
 	| anchoredImage url |
 	"for now I cancel the catching of all exceptions because it is a blackhole."
 	url := aFigure url.
 	anchoredImage := url scheme = 'file'
 		                 ifTrue: [ 
-							       aFigure originPath fileSystem / (url path)
-				                 binaryReadStreamDo: [ :stream | 
-				                 ImageReadWriter formFromStream: stream ] ]
+									(aFigure originPath fileSystem / (url path)) isFile
+										ifTrue: [ 
+											aFigure originPath fileSystem / (url path)
+				                 		binaryReadStreamDo: [ :stream | 
+				                 		ImageReadWriter formFromStream: stream ] 
+											]
+							        ]
 		                 ifFalse: [ self cachedImageFromUrl: url ].
-	anchoredImage := self resizeImage: anchoredImage of: aFigure.
-	anchoredImage := (String value: 1) asText addAttribute:
+	anchoredImage ifNotNil: [ 
+		anchoredImage := self resizeImage: anchoredImage of: aFigure.
+		anchoredImage := (String value: 1) asText addAttribute:
 		                 (TextAnchor new anchoredMorph: anchoredImage).
-	canvas << anchoredImage.
+		canvas << anchoredImage ].
+	
 	canvas newLine.
-	canvas includeAttribute: TextEmphasis bold in: [  ].
+	canvas includeAttribute: TextEmphasis bold in: [  ]].
 	"	on: Exception
 		do: [ self visitChildrenOf: aFigure ]. pay attention url return the rest https://files.pharo.org/media/logo/logo.png%7Csize=80&caption=Our%20great%20figure so we will have to add a method to only return the url part."
 	canvas

--- a/src/Microdown-MicrodownRichTextComposer/MicRichTextComposer.class.st
+++ b/src/Microdown-MicrodownRichTextComposer/MicRichTextComposer.class.st
@@ -709,7 +709,7 @@ MicRichTextComposer >> visitEnvironment: anObject [
 						'is not supported in RichText Pillar <<<') asText]
 ]
 
-{ #category : #'visiting - document' }
+{ #category : #'visiting - inline elements' }
 MicRichTextComposer >> visitFigure: aFigure [
 
 	"Try to read a png file (only one supported right now), else use alt text"
@@ -717,12 +717,12 @@ MicRichTextComposer >> visitFigure: aFigure [
 	| anchoredImage url |
 	"for now I cancel the catching of all exceptions because it is a blackhole."
 	url := aFigure url.
-	url scheme = 'file'
-		ifTrue: [ 
-			anchoredImage := FileSystem workingDirectory / url path 
+	anchoredImage := url scheme = 'file'
+		                 ifTrue: [ 
+			                 FileSystem workingDirectory / url path 
 				                 binaryReadStreamDo: [ :stream | 
 				                 ImageReadWriter formFromStream: stream ] ]
-		ifFalse: [ anchoredImage := self cachedImageFromUrl: url ].
+		                 ifFalse: [ self cachedImageFromUrl: url ].
 	anchoredImage := self resizeImage: anchoredImage of: aFigure.
 	anchoredImage := (String value: 1) asText addAttribute:
 		                 (TextAnchor new anchoredMorph: anchoredImage).

--- a/src/Microdown-MicrodownRichTextComposer/MicRichTextComposer.class.st
+++ b/src/Microdown-MicrodownRichTextComposer/MicRichTextComposer.class.st
@@ -720,8 +720,7 @@ MicRichTextComposer >> visitFigure: aFigure [
 	url := aFigure url.
 	anchoredImage := url scheme = 'file'
 		                 ifTrue: [ 
-								  self flag: 'fix url host'.
-			                 aFigure originPath fileSystem / (url path)
+							       aFigure originPath fileSystem / (url path)
 				                 binaryReadStreamDo: [ :stream | 
 				                 ImageReadWriter formFromStream: stream ] ]
 		                 ifFalse: [ self cachedImageFromUrl: url ].

--- a/src/Microdown-MicrodownRichTextComposer/MicRichTextComposer.class.st
+++ b/src/Microdown-MicrodownRichTextComposer/MicRichTextComposer.class.st
@@ -719,7 +719,8 @@ MicRichTextComposer >> visitFigure: aFigure [
 	url := aFigure url.
 	anchoredImage := url scheme = 'file'
 		                 ifTrue: [ 
-			                 FileSystem workingDirectory / url path 
+								  self flag: 'fix url host'.
+			                 aFigure currentSystem / (url host ,'/', url path)
 				                 binaryReadStreamDo: [ :stream | 
 				                 ImageReadWriter formFromStream: stream ] ]
 		                 ifFalse: [ self cachedImageFromUrl: url ].

--- a/src/Microdown-ResolvePath-Tests/MicResolvePathTest.class.st
+++ b/src/Microdown-ResolvePath-Tests/MicResolvePathTest.class.st
@@ -18,18 +18,19 @@ MicResolvePathTest >> setUp [
 ]
 
 { #category : #tests }
-MicResolvePathTest >> testResolveAbsolutePath [
-| file mic |
+MicResolvePathTest >> testResolveNotRelativePath [
+| file mic urlBefore |
 	system := FileSystem memory workingDirectory.
 	(system / 'folder') createDirectory.
 	file := system / 'folder/file.mic'.
 	file writeStreamDo: [ :stream | stream nextPutAll: '# section
 ![caption](file:///folder/image.png)' ].
 	mic := parser parseFile: file.
+	urlBefore := mic children second children first url asString.
 	self assert: mic children second children first isRelativeFilePath not.
 	resolver visit: mic.
 	self assert: mic children second children first isRelativeFilePath not.
-	self assert: mic children second children first url asString equals: 'file:///folder/image.png'
+	self assert: mic children second children first url asString equals: urlBefore
 	
 ]
 

--- a/src/Microdown-ResolvePath-Tests/MicResolvePathTest.class.st
+++ b/src/Microdown-ResolvePath-Tests/MicResolvePathTest.class.st
@@ -1,0 +1,49 @@
+Class {
+	#name : #MicResolvePathTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'resolver',
+		'system',
+		'parser'
+	],
+	#category : #'Microdown-ResolvePath-Tests'
+}
+
+{ #category : #running }
+MicResolvePathTest >> setUp [
+	super setUp.
+	resolver := MicResolvePath new.
+	system := FileSystem memory workingDirectory.
+	parser := MicroDownParser new
+]
+
+{ #category : #tests }
+MicResolvePathTest >> testResolveAbsolutePath [
+| file mic |
+	system := FileSystem memory workingDirectory.
+	(system / 'folder') createDirectory.
+	file := system / 'folder/file.mic'.
+	file writeStreamDo: [ :stream | stream nextPutAll: '# section
+![caption](file:///folder/image.png)' ].
+	mic := parser parseFile: file.
+	self assert: mic children second children first isRelativeFilePath not.
+	resolver visit: mic.
+	self assert: mic children second children first isRelativeFilePath not.
+	self assert: mic children second children first url asString equals: 'file:///folder/image.png'
+	
+]
+
+{ #category : #tests }
+MicResolvePathTest >> testResolveRelativePath [
+| file mic |
+	system := FileSystem memory workingDirectory.
+	(system / 'folder') createDirectory.
+	file := system / 'folder/file.mic'.
+	file writeStreamDo: [ :stream | stream nextPutAll: '# section
+![caption](file://figures/image.png)' ].
+	mic := parser parseFile: file.
+	self assert: mic children second children first isRelativeFilePath.
+	resolver visit: mic.
+	self assert: mic children second children first isRelativeFilePath not
+	
+]

--- a/src/Microdown-ResolvePath-Tests/package.st
+++ b/src/Microdown-ResolvePath-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Microdown-ResolvePath-Tests' }

--- a/src/Microdown-ResolvePath/MicResolvePath.class.st
+++ b/src/Microdown-ResolvePath/MicResolvePath.class.st
@@ -3,3 +3,14 @@ Class {
 	#superclass : #MicrodownVisitor,
 	#category : #'Microdown-ResolvePath'
 }
+
+{ #category : #visiting }
+MicResolvePath >> visitFigure: aFigure [
+	aFigure scheme = 'file' 
+		ifTrue: [ 
+			aFigure isRelativeFilePath 
+				ifTrue: [ aFigure propertyAt: #originPath put: aFigure originPath / ( aFigure url host ,'/', aFigure url path) ] 
+				ifFalse: [ aFigure propertyAt: #originPath put: FileSystem workingDirectory / ( aFigure url host ,'/', aFigure url path) ]
+			].
+	^ aFigure
+]

--- a/src/Microdown-ResolvePath/MicResolvePath.class.st
+++ b/src/Microdown-ResolvePath/MicResolvePath.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #MicResolvePath,
+	#superclass : #MicrodownVisitor,
+	#category : #'Microdown-ResolvePath'
+}

--- a/src/Microdown-ResolvePath/MicResolvePath.class.st
+++ b/src/Microdown-ResolvePath/MicResolvePath.class.st
@@ -6,10 +6,7 @@ Class {
 
 { #category : #visiting }
 MicResolvePath >> visitFigure: aFigure [
-	aFigure url scheme = 'file' 
-		ifTrue: [ 
-			aFigure isRelativeFilePath 
-				ifTrue: [ aFigure url: (aFigure originPath / ( aFigure url host ,'/', aFigure url path)) asUrl ]
-			].
+	(aFigure url scheme = 'file' and: [ aFigure isRelativeFilePath  ])
+			ifTrue: [ aFigure url: (aFigure originPath / ( aFigure url host ,'/', aFigure url path)) asUrl ].
 	^ aFigure
 ]

--- a/src/Microdown-ResolvePath/MicResolvePath.class.st
+++ b/src/Microdown-ResolvePath/MicResolvePath.class.st
@@ -6,11 +6,10 @@ Class {
 
 { #category : #visiting }
 MicResolvePath >> visitFigure: aFigure [
-	aFigure scheme = 'file' 
+	aFigure url scheme = 'file' 
 		ifTrue: [ 
 			aFigure isRelativeFilePath 
-				ifTrue: [ aFigure propertyAt: #originPath put: aFigure originPath / ( aFigure url host ,'/', aFigure url path) ] 
-				ifFalse: [ aFigure propertyAt: #originPath put: FileSystem workingDirectory / ( aFigure url host ,'/', aFigure url path) ]
+				ifTrue: [ aFigure url: (aFigure originPath / ( aFigure url host ,'/', aFigure url path)) asUrl ]
 			].
 	^ aFigure
 ]

--- a/src/Microdown-ResolvePath/package.st
+++ b/src/Microdown-ResolvePath/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Microdown-ResolvePath' }

--- a/src/Microdown-Tests/MicFigureBlockTest.class.st
+++ b/src/Microdown-Tests/MicFigureBlockTest.class.st
@@ -27,7 +27,7 @@ MicFigureBlockTest >> testCaption [
 { #category : #'tests - testing' }
 MicFigureBlockTest >> testIsNotRelativeFilePath [
 	| figure |
-	figure := (splitterClass new parse: '![caption](file://Users/name/figures/test.mic)') first.
+	figure := (splitterClass new parse: '![caption](file:///Users/name/figures/test.mic)') first.
 	self assert: figure isRelativeFilePath not
 ]
 

--- a/src/Microdown-Tests/MicFigureBlockTest.class.st
+++ b/src/Microdown-Tests/MicFigureBlockTest.class.st
@@ -25,6 +25,20 @@ MicFigureBlockTest >> testCaption [
 ]
 
 { #category : #tests }
+MicFigureBlockTest >> testIsNotRelativeFilePath [
+	| figure |
+	figure := (splitterClass new parse: '![caption](file://Users/name/figures/test.mic)') first.
+	self assert: figure isRelativeFilePath not
+]
+
+{ #category : #tests }
+MicFigureBlockTest >> testIsNotRelativeFilePathWithUrl [
+	| figure |
+	figure := (splitterClass new parse: '![caption](http://www.pharo.org)') first.
+	self assert: figure isRelativeFilePath not
+]
+
+{ #category : #tests }
 MicFigureBlockTest >> testIsNotValidImage [
 	| figure |
 	figure := (splitterClass new parse: '![caption](file://figures/test.mic)') first.
@@ -36,6 +50,13 @@ MicFigureBlockTest >> testIsNotValidImageWithFolder [
 	| figure |
 	figure := (splitterClass new parse: '![caption](file://figures/)') first.
 	self assert: figure isImageFile not
+]
+
+{ #category : #tests }
+MicFigureBlockTest >> testIsRelativeFilePath [
+	| figure |
+	figure := (splitterClass new parse: '![caption](file://figures/test.mic)') first.
+	self assert: figure isRelativeFilePath
 ]
 
 { #category : #tests }

--- a/src/Microdown-Tests/MicFigureBlockTest.class.st
+++ b/src/Microdown-Tests/MicFigureBlockTest.class.st
@@ -25,6 +25,27 @@ MicFigureBlockTest >> testCaption [
 ]
 
 { #category : #tests }
+MicFigureBlockTest >> testIsNotValidImage [
+	| figure |
+	figure := (splitterClass new parse: '![caption](file://figures/test.mic)') first.
+	self assert: figure isImageFile not
+]
+
+{ #category : #tests }
+MicFigureBlockTest >> testIsNotValidImageWithFolder [
+	| figure |
+	figure := (splitterClass new parse: '![caption](file://figures/)') first.
+	self assert: figure isImageFile not
+]
+
+{ #category : #tests }
+MicFigureBlockTest >> testIsValidImage [
+	| figure |
+	figure := (splitterClass new parse: '![caption](file://figures/test.png)') first.
+	self assert: figure isImageFile
+]
+
+{ #category : #tests }
 MicFigureBlockTest >> testPrintOn [
 	| figure |
 	figure := (splitterClass new parse: '![caption](http://www.Pharo.ORG)') first.

--- a/src/Microdown-Tests/MicFigureBlockTest.class.st
+++ b/src/Microdown-Tests/MicFigureBlockTest.class.st
@@ -24,42 +24,42 @@ MicFigureBlockTest >> testCaption [
 	
 ]
 
-{ #category : #tests }
+{ #category : #'tests - testing' }
 MicFigureBlockTest >> testIsNotRelativeFilePath [
 	| figure |
 	figure := (splitterClass new parse: '![caption](file://Users/name/figures/test.mic)') first.
 	self assert: figure isRelativeFilePath not
 ]
 
-{ #category : #tests }
+{ #category : #'tests - testing' }
 MicFigureBlockTest >> testIsNotRelativeFilePathWithUrl [
 	| figure |
 	figure := (splitterClass new parse: '![caption](http://www.pharo.org)') first.
 	self assert: figure isRelativeFilePath not
 ]
 
-{ #category : #tests }
+{ #category : #'tests - testing' }
 MicFigureBlockTest >> testIsNotValidImage [
 	| figure |
 	figure := (splitterClass new parse: '![caption](file://figures/test.mic)') first.
 	self assert: figure isImageFile not
 ]
 
-{ #category : #tests }
+{ #category : #'tests - testing' }
 MicFigureBlockTest >> testIsNotValidImageWithFolder [
 	| figure |
 	figure := (splitterClass new parse: '![caption](file://figures/)') first.
 	self assert: figure isImageFile not
 ]
 
-{ #category : #tests }
+{ #category : #'tests - testing' }
 MicFigureBlockTest >> testIsRelativeFilePath [
 	| figure |
 	figure := (splitterClass new parse: '![caption](file://figures/test.mic)') first.
 	self assert: figure isRelativeFilePath
 ]
 
-{ #category : #tests }
+{ #category : #'tests - testing' }
 MicFigureBlockTest >> testIsValidImage [
 	| figure |
 	figure := (splitterClass new parse: '![caption](file://figures/test.png)') first.

--- a/src/Microdown-Tests/MicInlineParserTest.class.st
+++ b/src/Microdown-Tests/MicInlineParserTest.class.st
@@ -90,6 +90,13 @@ MicInlineParserTest >> testCurlyBraceDoesNotLeadToProblem [
 	self assert: mic substring equals:  ' jhkjhk { a }'
 ]
 
+{ #category : #tests }
+MicInlineParserTest >> testCurrentSystemByDefault [ 
+	
+	self assert: self splitter currentSystem equals: FileSystem workingDirectory
+	
+]
+
 { #category : #'tests - escape' }
 MicInlineParserTest >> testEscapeCharacter [
 	"Test the escape \ in simple case (here, bold one)"

--- a/src/Microdown-Tests/MicInlineParserTest.class.st
+++ b/src/Microdown-Tests/MicInlineParserTest.class.st
@@ -90,13 +90,6 @@ MicInlineParserTest >> testCurlyBraceDoesNotLeadToProblem [
 	self assert: mic substring equals:  ' jhkjhk { a }'
 ]
 
-{ #category : #tests }
-MicInlineParserTest >> testCurrentSystemByDefault [ 
-	
-	self assert: self splitter currentSystem equals: FileSystem workingDirectory
-	
-]
-
 { #category : #'tests - escape' }
 MicInlineParserTest >> testEscapeCharacter [
 	"Test the escape \ in simple case (here, bold one)"

--- a/src/Microdown-Tests/MicroDownInlineParserTest.class.st
+++ b/src/Microdown-Tests/MicroDownInlineParserTest.class.st
@@ -220,7 +220,7 @@ MicrodownInlineParserTest >> testCurrentSystemInInlineParser [
 	file := system / 'folder/file.mic'.
 	file writeStreamDo: [ :stream | stream nextPutAll: '# section
 ![caption](file://folder/file.mic)' ].
-	mic := parser parseDocument: file.
+	mic := parser parseFile: file.
 	self assert: mic children second children first originPath equals: system / 'folder'
 ]
 

--- a/src/Microdown-Tests/MicroDownInlineParserTest.class.st
+++ b/src/Microdown-Tests/MicroDownInlineParserTest.class.st
@@ -210,20 +210,6 @@ MicrodownInlineParserTest >> testBoldsWithoutClosure [
  
 ]
 
-{ #category : #tests }
-MicrodownInlineParserTest >> testCurrentSystemInInlineParser [
-
-	| file system mic |
-	parser := self parser.
-	system := FileSystem memory workingDirectory.
-	(system / 'folder') createDirectory.
-	file := system / 'folder/file.mic'.
-	file writeStreamDo: [ :stream | stream nextPutAll: '# section
-![caption](file://folder/file.mic)' ].
-	mic := parser parseFile: file.
-	self assert: mic children second children first originPath equals: system / 'folder'
-]
-
 { #category : #'tests - others' }
 MicrodownInlineParserTest >> testEscape [
 
@@ -387,6 +373,20 @@ MicrodownInlineParserTest >> testMonospacesWithoutClosure [
  	self assert: elements size equals: 1.
  	self assert: elements first substring equals: 'abc`monospacesdef'
 
+]
+
+{ #category : #'tests - path' }
+MicrodownInlineParserTest >> testOriginPathInInlineParser [
+
+	| file system mic |
+	parser := self parser.
+	system := FileSystem memory workingDirectory.
+	(system / 'folder') createDirectory.
+	file := system / 'folder/file.mic'.
+	file writeStreamDo: [ :stream | stream nextPutAll: '# section
+![caption](file://folder/file.mic)' ].
+	mic := parser parseFile: file.
+	self assert: mic children second children first originPath equals: system / 'folder'
 ]
 
 { #category : #'tests - raw' }

--- a/src/Microdown-Tests/MicroDownInlineParserTest.class.st
+++ b/src/Microdown-Tests/MicroDownInlineParserTest.class.st
@@ -210,6 +210,20 @@ MicrodownInlineParserTest >> testBoldsWithoutClosure [
  
 ]
 
+{ #category : #tests }
+MicrodownInlineParserTest >> testCurrentSystemInInlineParser [
+
+	| file system mic |
+	parser := self parser.
+	system := FileSystem memory workingDirectory.
+	(system / 'folder') createDirectory.
+	file := system / 'folder/file.mic'.
+	file writeStreamDo: [ :stream | stream nextPutAll: '# section
+![caption](file://folder/file.mic)' ].
+	mic := parser parseDocument: file.
+	self assert: mic children second children first currentSystem equals: system / 'folder'
+]
+
 { #category : #'tests - others' }
 MicrodownInlineParserTest >> testEscape [
 

--- a/src/Microdown-Tests/MicroDownInlineParserTest.class.st
+++ b/src/Microdown-Tests/MicroDownInlineParserTest.class.st
@@ -221,7 +221,7 @@ MicrodownInlineParserTest >> testCurrentSystemInInlineParser [
 	file writeStreamDo: [ :stream | stream nextPutAll: '# section
 ![caption](file://folder/file.mic)' ].
 	mic := parser parseDocument: file.
-	self assert: mic children second children first currentSystem equals: system / 'folder'
+	self assert: mic children second children first originPath equals: system / 'folder'
 ]
 
 { #category : #'tests - others' }

--- a/src/Microdown-Tests/MicroDownParserTest.class.st
+++ b/src/Microdown-Tests/MicroDownParserTest.class.st
@@ -503,6 +503,17 @@ a paragraph' ].
 ]
 
 { #category : #'tests - path' }
+MicrodownParserTest >> testParseFileParseFilesDoesNotExist [
+
+	| file system mic |
+	system := FileSystem memory workingDirectory.
+	file := system / 'test.mic'.
+	mic := parser parseFile: file.
+	self assert: mic children first text equals: 'Your file is not valid'.
+	self assert: mic originPath equals: FileSystem workingDirectory
+]
+
+{ #category : #'tests - path' }
 MicrodownParserTest >> testParseFileParseFolder [
 
 	| folder system mic |

--- a/src/Microdown-Tests/MicroDownParserTest.class.st
+++ b/src/Microdown-Tests/MicroDownParserTest.class.st
@@ -242,6 +242,12 @@ MicrodownParserTest >> testCommentedLineMarkupInsideLine [
 ]
 
 { #category : #tests }
+MicrodownParserTest >> testCurrentSystemByDefault [
+
+	self assert: parser currentSystem equals: FileSystem workingDirectory
+]
+
+{ #category : #tests }
 MicrodownParserTest >> testEnvironmentCitationWithArguments [
 	| source root environmentName contents child |
 	environmentName := 'cite'.
@@ -479,6 +485,19 @@ MicrodownParserTest >> testMetaDataMultipleLines [
 "title": "Ze Great Book from Frenchies"'
 	"note that the closing is not part of the body"
 	
+]
+
+{ #category : #tests }
+MicrodownParserTest >> testParseDocument [
+
+	| file system |
+	system := FileSystem memory workingDirectory.
+	(system / 'folder') createDirectory.
+	file := system / 'folder/file.mic'.
+	file writeStreamDo: [ :stream | stream nextPutAll: '# section
+a paragraph' ].
+	parser parseDocument: file.
+	self assert: parser currentSystem equals: system / 'folder'
 ]
 
 { #category : #'tests - horizontal line' }

--- a/src/Microdown-Tests/MicroDownParserTest.class.st
+++ b/src/Microdown-Tests/MicroDownParserTest.class.st
@@ -242,12 +242,6 @@ MicrodownParserTest >> testCommentedLineMarkupInsideLine [
 ]
 
 { #category : #tests }
-MicrodownParserTest >> testCurrentSystemByDefault [
-
-	self assert: parser currentSystem equals: FileSystem workingDirectory
-]
-
-{ #category : #tests }
 MicrodownParserTest >> testEnvironmentCitationWithArguments [
 	| source root environmentName contents child |
 	environmentName := 'cite'.
@@ -487,28 +481,37 @@ MicrodownParserTest >> testMetaDataMultipleLines [
 	
 ]
 
-{ #category : #tests }
+{ #category : #'tests - path' }
+MicrodownParserTest >> testOriginPathIsAbsent [
+	| mic |
+	mic := parser parse: '# section
+a paragraph'.
+	self assert: mic originPath equals: FileSystem workingDirectory
+]
+
+{ #category : #'tests - path' }
 MicrodownParserTest >> testParseDocument [
 
-	| file system |
+	| file system mic |
 	system := FileSystem memory workingDirectory.
 	(system / 'folder') createDirectory.
 	file := system / 'folder/file.mic'.
 	file writeStreamDo: [ :stream | stream nextPutAll: '# section
 a paragraph' ].
-	parser parseDocument: file.
-	self assert: parser currentSystem equals: system / 'folder'
+	mic := parser parseDocument: file.
+	self assert: mic originPath equals: system / 'folder'
 ]
 
-{ #category : #tests }
+{ #category : #'tests - path' }
 MicrodownParserTest >> testParseDocumentParseFolder [
 
-	| folder system |
+	| folder system mic |
 	system := FileSystem memory workingDirectory.
 	(system / 'folder') createDirectory.
 	folder := system / 'folder'.
-	parser parseDocument: folder.
-	self assert: parser currentSystem equals: FileSystem workingDirectory
+	mic := parser parseDocument: folder.
+	self assert: mic children first text equals: 'Your file is not valid'.
+	self assert: mic originPath equals: FileSystem workingDirectory
 ]
 
 { #category : #'tests - horizontal line' }

--- a/src/Microdown-Tests/MicroDownParserTest.class.st
+++ b/src/Microdown-Tests/MicroDownParserTest.class.st
@@ -490,7 +490,7 @@ a paragraph'.
 ]
 
 { #category : #'tests - path' }
-MicrodownParserTest >> testParseDocument [
+MicrodownParserTest >> testParseFile [
 
 	| file system mic |
 	system := FileSystem memory workingDirectory.
@@ -503,7 +503,7 @@ a paragraph' ].
 ]
 
 { #category : #'tests - path' }
-MicrodownParserTest >> testParseDocumentParseFolder [
+MicrodownParserTest >> testParseFileParseFolder [
 
 	| folder system mic |
 	system := FileSystem memory workingDirectory.

--- a/src/Microdown-Tests/MicroDownParserTest.class.st
+++ b/src/Microdown-Tests/MicroDownParserTest.class.st
@@ -498,7 +498,7 @@ MicrodownParserTest >> testParseDocument [
 	file := system / 'folder/file.mic'.
 	file writeStreamDo: [ :stream | stream nextPutAll: '# section
 a paragraph' ].
-	mic := parser parseDocument: file.
+	mic := parser parseFile: file.
 	self assert: mic originPath equals: system / 'folder'
 ]
 
@@ -509,7 +509,7 @@ MicrodownParserTest >> testParseDocumentParseFolder [
 	system := FileSystem memory workingDirectory.
 	(system / 'folder') createDirectory.
 	folder := system / 'folder'.
-	mic := parser parseDocument: folder.
+	mic := parser parseFile: folder.
 	self assert: mic children first text equals: 'Your file is not valid'.
 	self assert: mic originPath equals: FileSystem workingDirectory
 ]

--- a/src/Microdown-Tests/MicroDownParserTest.class.st
+++ b/src/Microdown-Tests/MicroDownParserTest.class.st
@@ -500,6 +500,17 @@ a paragraph' ].
 	self assert: parser currentSystem equals: system / 'folder'
 ]
 
+{ #category : #tests }
+MicrodownParserTest >> testParseDocumentParseFolder [
+
+	| folder system |
+	system := FileSystem memory workingDirectory.
+	(system / 'folder') createDirectory.
+	folder := system / 'folder'.
+	parser parseDocument: folder.
+	self assert: parser currentSystem equals: FileSystem workingDirectory
+]
+
 { #category : #'tests - horizontal line' }
 MicrodownParserTest >> testParseLineWithOneCharacter [ 
 	

--- a/src/Microdown/MicAbstractBlock.class.st
+++ b/src/Microdown/MicAbstractBlock.class.st
@@ -10,10 +10,8 @@ Class {
 	#name : #MicAbstractBlock,
 	#superclass : #MicElement,
 	#instVars : [
-		'parent',
 		'children',
-		'parser',
-		'properties'
+		'parser'
 	],
 	#category : #'Microdown-Model'
 }
@@ -125,17 +123,6 @@ MicAbstractBlock >> newBlockFor: line parent: parentBlock [
 		addLineAndReturnNextNode: line
 ]
 
-{ #category : #accessing }
-MicAbstractBlock >> parent [
-	^ parent
-]
-
-{ #category : #accessing }
-MicAbstractBlock >> parent: aBlock [
-	parent := aBlock.
-	aBlock addChild: self
-]
-
 { #category : #private }
 MicAbstractBlock >> parser [
 	^ parser 
@@ -144,66 +131,6 @@ MicAbstractBlock >> parser [
 { #category : #private }
 MicAbstractBlock >> parserClass [ 
 	^ MicroDownParser 
-]
-
-{ #category : #properties }
-MicAbstractBlock >> properties [
-	^ properties ifNil: [ properties := Dictionary new ]
-]
-
-{ #category : #properties }
-MicAbstractBlock >> propertiesCopy [
-	self properties ifNil: [ ^ nil ].
-	^ self properties collect: [ :each | each copy ]
-]
-
-{ #category : #properties }
-MicAbstractBlock >> propertyAt: aKey [
-	"Answer the property value associated with aKey."
-	
-	^ self propertyAt: aKey ifAbsent: [ MicPropertyError signal: 'Property not found' ]
-]
-
-{ #category : #properties }
-MicAbstractBlock >> propertyAt: aKey ifAbsent: aBlock [
-	"Answer the property value associated with aKey or, if aKey isn't found, answer the result of evaluating aBlock."
-	
-	^ self properties isNil
-		ifTrue: [ aBlock value ]
-		ifFalse: [ self properties at: aKey ifAbsent: aBlock ]
-]
-
-{ #category : #properties }
-MicAbstractBlock >> propertyAt: aKey ifAbsentPut: aBlock [
-	"Answer the property associated with aKey or, if aKey isn't found store the result of evaluating aBlock as new value."
-	
-	^ self propertyAt: aKey ifAbsent: [ self propertyAt: aKey put: aBlock value ]
-]
-
-{ #category : #properties }
-MicAbstractBlock >> propertyAt: aKey put: anObject [
-	"Set the property at aKey to be anObject. If aKey is not found, create a new entry for aKey and set is value to anObject. Answer anObject."
-
-	^ (properties ifNil: [ properties := (IdentityDictionary new: 1) ])
-		at: aKey put: anObject
-]
-
-{ #category : #properties }
-MicAbstractBlock >> removeProperty: aKey [
-	"Remove the property with aKey. Answer the property or raise an error if aKey isn't found."
-	
-	^ self removeProperty: aKey ifAbsent: [ MicPropertyError signal: 'Property not found' ]
-]
-
-{ #category : #properties }
-MicAbstractBlock >> removeProperty: aKey ifAbsent: aBlock [
-	"Remove the property with aKey. Answer the value or, if aKey isn't found, answer the result of evaluating aBlock."
-	
-	| answer |
-	self properties ifNil: [ ^ aBlock value ].
-	answer := self properties removeKey: aKey ifAbsent: aBlock.
-	self properties isEmpty ifTrue: [ properties := nil ].
-	^ answer
 ]
 
 { #category : #private }

--- a/src/Microdown/MicCodeBlock.class.st
+++ b/src/Microdown/MicCodeBlock.class.st
@@ -68,6 +68,26 @@ MicCodeBlock >> evaluate [
 		do: [ :e | MicBoldFormatBlock new children: { (MicTextBlock new substring: e messageText) } ]
 ]
 
+{ #category : #evaluation }
+MicCodeBlock >> evaluationString [
+	^ String
+		streamContents: [ :stream | 
+			| evaluator |
+			evaluator := MicCodeblockEvaluatorEnv new
+				setStream: stream;
+				yourself.
+			[ self class compiler
+				source: self body;
+				logged: false;
+				receiver: evaluator;
+				evaluate ]
+				on: Error
+				do: [ :e | 
+					stream
+						nextPutAll: '= ';
+						nextPutAll: e description ] ]
+]
+
 { #category : #handle }
 MicCodeBlock >> extractFirstLineFrom: aLine [
 	"language=Pharo&label=fig1&caption=La vie est belle"

--- a/src/Microdown/MicElement.class.st
+++ b/src/Microdown/MicElement.class.st
@@ -1,14 +1,91 @@
 Class {
 	#name : #MicElement,
 	#superclass : #Object,
+	#instVars : [
+		'parent',
+		'properties'
+	],
 	#category : #'Microdown-Model'
 }
 
 { #category : #public }
 MicElement >> inlineParse: aString [
-	| inlineParser |
+	| inlineParser childrenCol |
 	inlineParser := MicInlineParser new.
 	inlineParser currentSystem: self parser currentSystem.
-	^  inlineParser parse: aString
+	childrenCol := inlineParser parse: aString.
+	childrenCol do: [ :each | each parent: self ].
+	^  childrenCol
 
+]
+
+{ #category : #accessing }
+MicElement >> parent [
+	^ parent
+]
+
+{ #category : #accessing }
+MicElement >> parent: aBlock [
+	parent := aBlock.
+	aBlock addChild: self
+]
+
+{ #category : #properties }
+MicElement >> properties [
+	^ properties ifNil: [ properties := Dictionary new ]
+]
+
+{ #category : #properties }
+MicElement >> propertiesCopy [
+	self properties ifNil: [ ^ nil ].
+	^ self properties collect: [ :each | each copy ]
+]
+
+{ #category : #properties }
+MicElement >> propertyAt: aKey [
+	"Answer the property value associated with aKey."
+	
+	^ self propertyAt: aKey ifAbsent: [ MicPropertyError signal: 'Property not found' ]
+]
+
+{ #category : #properties }
+MicElement >> propertyAt: aKey ifAbsent: aBlock [
+	"Answer the property value associated with aKey or, if aKey isn't found, answer the result of evaluating aBlock."
+	
+	^ self properties isNil
+		ifTrue: [ aBlock value ]
+		ifFalse: [ self properties at: aKey ifAbsent: aBlock ]
+]
+
+{ #category : #properties }
+MicElement >> propertyAt: aKey ifAbsentPut: aBlock [
+	"Answer the property associated with aKey or, if aKey isn't found store the result of evaluating aBlock as new value."
+	
+	^ self propertyAt: aKey ifAbsent: [ self propertyAt: aKey put: aBlock value ]
+]
+
+{ #category : #properties }
+MicElement >> propertyAt: aKey put: anObject [
+	"Set the property at aKey to be anObject. If aKey is not found, create a new entry for aKey and set is value to anObject. Answer anObject."
+
+	^ (properties ifNil: [ properties := (IdentityDictionary new: 1) ])
+		at: aKey put: anObject
+]
+
+{ #category : #properties }
+MicElement >> removeProperty: aKey [
+	"Remove the property with aKey. Answer the property or raise an error if aKey isn't found."
+	
+	^ self removeProperty: aKey ifAbsent: [ MicPropertyError signal: 'Property not found' ]
+]
+
+{ #category : #properties }
+MicElement >> removeProperty: aKey ifAbsent: aBlock [
+	"Remove the property with aKey. Answer the value or, if aKey isn't found, answer the result of evaluating aBlock."
+	
+	| answer |
+	self properties ifNil: [ ^ aBlock value ].
+	answer := self properties removeKey: aKey ifAbsent: aBlock.
+	self properties isEmpty ifTrue: [ properties := nil ].
+	^ answer
 ]

--- a/src/Microdown/MicElement.class.st
+++ b/src/Microdown/MicElement.class.st
@@ -19,6 +19,12 @@ MicElement >> inlineParse: aString [
 ]
 
 { #category : #accessing }
+MicElement >> originPath [
+	^ self properties at: #originPath 
+		ifAbsent: [ ^ parent originPath  ]
+]
+
+{ #category : #accessing }
 MicElement >> parent [
 	^ parent
 ]

--- a/src/Microdown/MicElement.class.st
+++ b/src/Microdown/MicElement.class.st
@@ -6,7 +6,9 @@ Class {
 
 { #category : #public }
 MicElement >> inlineParse: aString [
-
-	^ MicInlineParser new parse: aString
+	| inlineParser |
+	inlineParser := MicInlineParser new.
+	inlineParser currentSystem: self parser currentSystem.
+	^  inlineParser parse: aString
 
 ]

--- a/src/Microdown/MicElement.class.st
+++ b/src/Microdown/MicElement.class.st
@@ -12,7 +12,6 @@ Class {
 MicElement >> inlineParse: aString [
 	| inlineParser childrenCol |
 	inlineParser := MicInlineParser new.
-	inlineParser currentSystem: self parser currentSystem.
 	childrenCol := inlineParser parse: aString.
 	childrenCol do: [ :each | each parent: self ].
 	^  childrenCol

--- a/src/Microdown/MicFigureBlock.class.st
+++ b/src/Microdown/MicFigureBlock.class.st
@@ -55,6 +55,20 @@ MicFigureBlock >> hasCaption [
 	^ true
 ]
 
+{ #category : #testing }
+MicFigureBlock >> isImageFile [
+	"Answer whether the file name indicates an image file."
+
+	url asString ifNil: [^false].
+	^#('pcx' 'bmp' 'jpeg' 'xbm' 'pnm' 'ppm' 'gif' 'pam' 'jpg' 'png' 'pbm')
+		includes: url asString asFileReference extension asLowercase
+]
+
+{ #category : #testing }
+MicFigureBlock >> isRelativeFilePath [
+	^ self url scheme = 'file' and: [ (self url host asLowercase = 'users') not ]
+]
+
 { #category : #accessing }
 MicFigureBlock >> kind [
 

--- a/src/Microdown/MicFigureBlock.class.st
+++ b/src/Microdown/MicFigureBlock.class.st
@@ -66,7 +66,7 @@ MicFigureBlock >> isImageFile [
 
 { #category : #testing }
 MicFigureBlock >> isRelativeFilePath [
-	^ self url scheme = 'file' and: [ (self url host asLowercase = 'users') not ]
+	^ self url scheme = 'file' and: [ (self url asString beginsWith: 'file:///') not ]
 ]
 
 { #category : #accessing }

--- a/src/Microdown/MicFigureBlock.class.st
+++ b/src/Microdown/MicFigureBlock.class.st
@@ -40,7 +40,7 @@ MicFigureBlock >> closeMe [
 	
 	| dictionary |
 	dictionary := OrderedDictionary new. 
-	url := (ZnUrl fromString: url).
+	url := (ZnUrl fromString: url asString).
 	url query ifNotNil: [ :q |
 		q keysAndValuesDo: [ :k :v | dictionary at: k put: v  ] ].
 	self arguments: dictionary.

--- a/src/Microdown/MicInlineBlockWithUrl.class.st
+++ b/src/Microdown/MicInlineBlockWithUrl.class.st
@@ -31,6 +31,20 @@ MicInlineBlockWithUrl class >> from: aStartInteger to: anEndInteger withKind: aK
 ]
 
 { #category : #'instance creation' }
+MicInlineBlockWithUrl class >> from: aStartInteger to: anEndInteger withKind: aKind withSubstring: aString withChildren: aChildren withURL: aURL withParser: aParser [
+	^ self new 
+		start: aStartInteger; 
+		end: anEndInteger; 
+		substring: aString; 
+		children: aChildren; 
+		cleanSubstring; 
+		url: aURL;
+		parser: aParser;
+		closeMe; 
+		yourself
+]
+
+{ #category : #'instance creation' }
 MicInlineBlockWithUrl class >> from: aStartInteger to: anEndInteger withKind: aKind withSubstring: aString withURL: aURL [
 	^ (self from: aStartInteger to: anEndInteger withKind: aKind withSubstring: aString withChildren: Array empty withURL: aURL)
 ]

--- a/src/Microdown/MicInlineBlockWithUrl.class.st
+++ b/src/Microdown/MicInlineBlockWithUrl.class.st
@@ -12,7 +12,8 @@ Class {
 	#superclass : #MicInlineElement,
 	#instVars : [
 		'url',
-		'caption'
+		'caption',
+		'parser'
 	],
 	#category : #'Microdown-ModelInline'
 }
@@ -63,6 +64,21 @@ MicInlineBlockWithUrl >> captionElements [
 MicInlineBlockWithUrl >> closingDelimiter [
 
  	^ MicURLCloserDelimiter markup
+]
+
+{ #category : #accessing }
+MicInlineBlockWithUrl >> currentSystem [ 
+	^ parser currentSystem
+]
+
+{ #category : #accessing }
+MicInlineBlockWithUrl >> parser [ 
+	^ parser
+]
+
+{ #category : #accessing }
+MicInlineBlockWithUrl >> parser: aParser [
+	parser := aParser
 ]
 
 { #category : #printing }

--- a/src/Microdown/MicInlineBlockWithUrl.class.st
+++ b/src/Microdown/MicInlineBlockWithUrl.class.st
@@ -76,11 +76,6 @@ MicInlineBlockWithUrl >> closingDelimiter [
 ]
 
 { #category : #accessing }
-MicInlineBlockWithUrl >> currentSystem [ 
-	^ parser currentSystem
-]
-
-{ #category : #accessing }
 MicInlineBlockWithUrl >> localFileOrExternalReference [
 	^ self class localFileOrExternalReference: url asString
 ]

--- a/src/Microdown/MicInlineElement.class.st
+++ b/src/Microdown/MicInlineElement.class.st
@@ -119,6 +119,11 @@ MicInlineElement >> literal [
 	^ substring copyFrom: start to: end. 
 ]
 
+{ #category : #accessing }
+MicInlineElement >> parent: aParent [
+	parent := aParent
+]
+
 { #category : #printing }
 MicInlineElement >> printOn: aStream [
 

--- a/src/Microdown/MicInlineParser.class.st
+++ b/src/Microdown/MicInlineParser.class.st
@@ -101,6 +101,7 @@ MicInlineParser >> closerOnlyCase [
 
 { #category : #accessing }
 MicInlineParser >> currentSystem [
+	currentSystem ifNil: [ ^ FileSystem workingDirectory ].
 	^ currentSystem
 ]
 

--- a/src/Microdown/MicInlineParser.class.st
+++ b/src/Microdown/MicInlineParser.class.st
@@ -18,7 +18,8 @@ Class {
 		'correctSubstring',
 		'correctURL',
 		'keys',
-		'delimiterClass'
+		'delimiterClass',
+		'currentSystem'
 	],
 	#category : #'Microdown-Parser'
 }
@@ -96,6 +97,16 @@ MicInlineParser >> closerOnlyCase [
 		ifFalse: [ Array braceWith: delimiterClass type ].
 	indexOfAssociateOpener := openersStack findFirst: [ :each | typesToFind includes: each type ].
 	(indexOfAssociateOpener > 0) ifTrue: [ self addInlineBlock: indexOfAssociateOpener ]
+]
+
+{ #category : #accessing }
+MicInlineParser >> currentSystem [
+	^ currentSystem
+]
+
+{ #category : #accessing }
+MicInlineParser >> currentSystem: aFileReference [
+	currentSystem := aFileReference
 ]
 
 { #category : #process }
@@ -298,6 +309,7 @@ MicInlineParser >> newURLInlineBlockWithCloser: aCloserIndex [
 				withSubstring: correctSubstring
 				withChildren: children asArray
 				withURL: correctURL
+				withParser: self
 		 ]
 		ifFalse: [ ^ self newURLInlineBlockWithoutChildren ]
 	

--- a/src/Microdown/MicInlineParser.class.st
+++ b/src/Microdown/MicInlineParser.class.st
@@ -18,8 +18,7 @@ Class {
 		'correctSubstring',
 		'correctURL',
 		'keys',
-		'delimiterClass',
-		'currentSystem'
+		'delimiterClass'
 	],
 	#category : #'Microdown-Parser'
 }
@@ -97,17 +96,6 @@ MicInlineParser >> closerOnlyCase [
 		ifFalse: [ Array braceWith: delimiterClass type ].
 	indexOfAssociateOpener := openersStack findFirst: [ :each | typesToFind includes: each type ].
 	(indexOfAssociateOpener > 0) ifTrue: [ self addInlineBlock: indexOfAssociateOpener ]
-]
-
-{ #category : #accessing }
-MicInlineParser >> currentSystem [
-	currentSystem ifNil: [ ^ FileSystem workingDirectory ].
-	^ currentSystem
-]
-
-{ #category : #accessing }
-MicInlineParser >> currentSystem: aFileReference [
-	currentSystem := aFileReference
 ]
 
 { #category : #process }

--- a/src/Microdown/MicRootBlock.class.st
+++ b/src/Microdown/MicRootBlock.class.st
@@ -34,3 +34,9 @@ MicRootBlock >> canConsumeLine: line [
 MicRootBlock >> indent [
 	^0
 ]
+
+{ #category : #accessing }
+MicRootBlock >> originPath [
+	^ self properties at: #originPath 
+		ifAbsent: [ ^ FileSystem workingDirectory ]
+]

--- a/src/Microdown/MicroDownParser.class.st
+++ b/src/Microdown/MicroDownParser.class.st
@@ -668,12 +668,12 @@ MicroDownParser >> parse: aStreamOrString [
 	^ root
 ]
 
-{ #category : #markups }
+{ #category : #parsing }
 MicroDownParser >> parseDocument: aFileReference [
 	| currentPath |
 	currentPath := ''.
 	aFileReference pathSegments allButLast do: [ :each | currentPath := currentPath , '/' , each ].
-	currentSystem := FileSystem workingDirectory / currentPath.
+	currentSystem := aFileReference fileSystem workingDirectory / currentPath.
 	^ self parse: aFileReference contents
 ]
 

--- a/src/Microdown/MicroDownParser.class.st
+++ b/src/Microdown/MicroDownParser.class.st
@@ -159,8 +159,7 @@ Class {
 	#instVars : [
 		'current',
 		'root',
-		'dispatchTable',
-		'currentSystem'
+		'dispatchTable'
 	],
 	#classInstVars : [
 		'inlineMarkups'
@@ -519,12 +518,6 @@ MicroDownParser >> commentedLineMarkup [
 MicroDownParser >> current [ 
 
 	^ current
-]
-
-{ #category : #accessing }
-MicroDownParser >> currentSystem [
-	currentSystem ifNil: [ ^ FileSystem workingDirectory ].
-	^ currentSystem
 ]
 
 { #category : #markups }

--- a/src/Microdown/MicroDownParser.class.st
+++ b/src/Microdown/MicroDownParser.class.st
@@ -662,7 +662,7 @@ MicroDownParser >> parse: aStreamOrString [
 ]
 
 { #category : #parsing }
-MicroDownParser >> parseDocument: aFileReference [
+MicroDownParser >> parseFile: aFileReference [
 	| micTree |
 	aFileReference isFile 
 		ifTrue: [ 

--- a/src/Microdown/MicroDownParser.class.st
+++ b/src/Microdown/MicroDownParser.class.st
@@ -670,11 +670,14 @@ MicroDownParser >> parse: aStreamOrString [
 
 { #category : #parsing }
 MicroDownParser >> parseDocument: aFileReference [
-	| currentPath |
-	currentPath := ''.
-	aFileReference pathSegments allButLast do: [ :each | currentPath := currentPath , '/' , each ].
-	currentSystem := aFileReference fileSystem workingDirectory / currentPath.
-	^ self parse: aFileReference contents
+	aFileReference isFile 
+		ifTrue: [ 
+			| currentPath |
+			currentPath := ''.
+			aFileReference pathSegments allButLast do: [ :each | currentPath := currentPath , '/' , each ].
+			currentSystem := aFileReference fileSystem workingDirectory / currentPath.
+			^ self parse: aFileReference contents ]
+	
 ]
 
 { #category : #markups }

--- a/src/Microdown/MicroDownParser.class.st
+++ b/src/Microdown/MicroDownParser.class.st
@@ -523,6 +523,7 @@ MicroDownParser >> current [
 
 { #category : #accessing }
 MicroDownParser >> currentSystem [
+	currentSystem ifNil: [ ^ FileSystem workingDirectory ].
 	^ currentSystem
 ]
 

--- a/src/Microdown/MicroDownParser.class.st
+++ b/src/Microdown/MicroDownParser.class.st
@@ -159,7 +159,8 @@ Class {
 	#instVars : [
 		'current',
 		'root',
-		'dispatchTable'
+		'dispatchTable',
+		'currentSystem'
 	],
 	#classInstVars : [
 		'inlineMarkups'
@@ -520,6 +521,11 @@ MicroDownParser >> current [
 	^ current
 ]
 
+{ #category : #accessing }
+MicroDownParser >> currentSystem [
+	^ currentSystem
+]
+
 { #category : #markups }
 MicroDownParser >> environmentClosingBlockMarkup [
 	^ self class environmentClosingBlockMarkup
@@ -659,6 +665,15 @@ MicroDownParser >> parse: aStreamOrString [
 		whileFalse: [ current closeMe.
 			current := current parent ].
 	^ root
+]
+
+{ #category : #markups }
+MicroDownParser >> parseDocument: aFileReference [
+	| currentPath |
+	currentPath := ''.
+	aFileReference pathSegments allButLast do: [ :each | currentPath := currentPath , '/' , each ].
+	currentSystem := FileSystem workingDirectory / currentPath.
+	^ self parse: aFileReference contents
 ]
 
 { #category : #markups }

--- a/src/Microdown/MicroDownParser.class.st
+++ b/src/Microdown/MicroDownParser.class.st
@@ -663,13 +663,17 @@ MicroDownParser >> parse: aStreamOrString [
 
 { #category : #parsing }
 MicroDownParser >> parseDocument: aFileReference [
+	| micTree |
 	aFileReference isFile 
 		ifTrue: [ 
 			| currentPath |
+			micTree := self parse: aFileReference contents.
 			currentPath := ''.
 			aFileReference pathSegments allButLast do: [ :each | currentPath := currentPath , '/' , each ].
-			currentSystem := aFileReference fileSystem workingDirectory / currentPath.
-			^ self parse: aFileReference contents ]
+			micTree propertyAt: #originPath put: aFileReference fileSystem workingDirectory / currentPath.
+			^ micTree ]
+		ifFalse: [ 
+			^ self parse: 'Your file is not valid' ]
 	
 ]
 


### PR DESCRIPTION
- parent and properties push up in MicElement
- add parseFile method
- MicRoot stock the originPath
- MicFigure
    - add isImageFile
    - add isRelativeFilePath
- add new visitor MicResolvePath
- make visitFigure of MicRichTextComposer more robust