### PR TITLE
Fixes #233. Rendering of tables (as forms) in rich text.

### DIFF
--- a/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
+++ b/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
@@ -609,6 +609,14 @@ MicRichTextComposer >> renderMathExpression: aString [
 	canvas << (self class latexMathStylerFor: aString)
 ]
 
+{ #category : #private }
+MicRichTextComposer >> renderTableCell: aCell [
+	"a cell is an array of nodes. Each element should be rendered and concatenated"
+	^ aCell inject: Text new into: [ :txt :part | 
+		txt, (MicRichTextComposer new visit: part)
+		 ]
+]
+
 { #category : #'visiting - document' }
 MicRichTextComposer >> resizeImage: anImage of: aFigure [
 
@@ -904,6 +912,29 @@ MicRichTextComposer >> visitStrike: anObject [
 	canvas 
 		includeAttribute: TextEmphasis struckOut 
 		in: [ super visitStrike: anObject ]
+]
+
+{ #category : #'visiting -  format' }
+MicRichTextComposer >> visitTable: tableBlock [
+	"I render the using MicRichTable which is dedicated to this. I insert the table as an image (form)"
+	| headers rows table anchoredTable renderedRows |
+	renderedRows := tableBlock rows collect: [ :oneRow | oneRow collect: [ :cell | self renderTableCell: cell ]].
+	tableBlock hasHeader
+		ifTrue: [ 
+			headers := renderedRows first. 
+			rows := renderedRows allButFirst  ]
+		ifFalse: [ 
+			headers := (1 to: renderedRows first size) collect: [:i | i printString asText].
+			rows := renderedRows].
+	"Create the Morphic Table and insert it"
+	table := MicRichTextTable headers: headers rows: rows.
+	tableBlock hasHeader
+		ifFalse: [ 
+			table extent: table extent - (0 @ '1' asTextMorph height). "not showing the headers"
+			table hideColumnHeaders  ].
+	anchoredTable := (String value: 1) asText addAttribute: (TextAnchor new anchoredMorph: table asForm).
+	canvas << anchoredTable
+	
 ]
 
 { #category : #'visiting -  format' }

--- a/src/Microdown-RichTextComposer/MicRichTextTable.class.st
+++ b/src/Microdown-RichTextComposer/MicRichTextTable.class.st
@@ -1,0 +1,61 @@
+"
+I am a Morphic table used by `MicRichTextComposer>>visitTable:` to render tables. I serve no other purpose. 
+"
+Class {
+	#name : #MicRichTextTable,
+	#superclass : #FTTableMorph,
+	#category : #'Microdown-RichTextComposer'
+}
+
+{ #category : #'as yet unclassified' }
+MicRichTextTable class >> headers: headers rows: rows [
+	"headers is an array of column names, and rows are an array of array of string"
+	^ self new headers: headers rows: rows
+]
+
+{ #category : #adding }
+MicRichTextTable >> addHeaders: headers with: renderedRows [
+	|totalWidth totalHeight  |
+	totalWidth := 0.
+	totalHeight := 0.
+	1 to: headers size do:[ :colIndex | |header colRows colWidth colHeight|
+		header := headers at: colIndex.
+		colRows := renderedRows collect: [ :row | row at: colIndex  ].
+		colWidth := (header asTextMorph width) 
+					max: (colRows collect: [:cell| cell asTextMorph width]) max.
+		totalWidth := totalWidth + colWidth.
+		colHeight := header asTextMorph height 
+				+ ((colRows collect: [:cell| cell asTextMorph height]) sum).
+		totalHeight := totalHeight max: colHeight.
+		self addColumn: ((FTColumn id: header) width: colWidth +5 )
+	].
+	self extent: (totalWidth + (headers size * 5)) @ (totalHeight+(renderedRows size +1 *5) )
+]
+
+{ #category : #'as yet unclassified' }
+MicRichTextTable >> headers: headers rows: rows [
+	self
+		addHeaders: headers with: rows ;
+		dataSource: (MicRichTextTableDataSource headers: headers rows: rows);
+		beRowNotHomogeneous.
+		
+	
+]
+
+{ #category : #rendering }
+MicRichTextTable >> renderCell: aCell [
+	"a cell is an array of nodes. Each element should be rendered and concatenated"
+	^ aCell inject: Text new into: [ :txt :part | 
+		txt, (MicRichTextComposer new visit: part)
+		 ]
+]
+
+{ #category : #private }
+MicRichTextTable >> resizeAllSubviews [
+	"This method is just like its super, except it prevents the vertical scroll bar to appear"
+	self resizeContainer.
+	self container setNeedsRefreshExposedRows.
+	self container updateExposedRows.
+	function isExplicit
+		ifTrue: [ function resizeWidget ]
+]

--- a/src/Microdown-RichTextComposer/MicRichTextTableDataSource.class.st
+++ b/src/Microdown-RichTextComposer/MicRichTextTableDataSource.class.st
@@ -1,0 +1,94 @@
+"
+I am a morphic table datasource for rendering tables inside rich text.
+I serve only that one purpose.
+"
+Class {
+	#name : #MicRichTextTableDataSource,
+	#superclass : #FTSimpleDataSource,
+	#instVars : [
+		'colNames',
+		'rows'
+	],
+	#category : #'Microdown-RichTextComposer'
+}
+
+{ #category : #'as yet unclassified' }
+MicRichTextTableDataSource class >> headers: headers rows: theRows [
+	^ self new headers: headers rows: theRows
+]
+
+{ #category : #accessing }
+MicRichTextTableDataSource >> basicHeaderCellFor: column [
+	| cell |
+	column id ifNil: [ ^ nil ].
+	cell := FTHeaderColumnCellMorph new
+		column: column;
+		cellInset: 5;
+		addMorph: column id asTextMorph;
+		yourself.
+
+	^ cell
+]
+
+{ #category : #accessing }
+MicRichTextTableDataSource >> cellColumn: column row: rowIndex [
+	"Answer a morph with the cell view. I will probably return a FTCellMorph."
+	| cell |
+	cell  := ((rows at: rowIndex )at: (colNames at: column id )).
+	^ FTCellMorph new
+		addMorph: cell asTextMorph;
+		yourself
+]
+
+{ #category : #private }
+MicRichTextTableDataSource >> elementAt: rowIndex [
+	"I am a really important method for a DataSource. I take an index and I return an object 
+	 that should be displayed in the table for the index."
+	rows at: rowIndex 
+]
+
+{ #category : #'as yet unclassified' }
+MicRichTextTableDataSource >> headers: headers rows: theRows [
+	rows := theRows.
+	colNames := Dictionary new.
+	1 to: headers size do: [ :index | colNames at: (headers at: index) put: index ]
+]
+
+{ #category : #accessing }
+MicRichTextTableDataSource >> numberOfRows [
+	"I return the number of elements I can display in the table when I am call."
+
+	^ rows size
+]
+
+{ #category : #accessing }
+MicRichTextTableDataSource >> rowHeight: rowIndex [
+	^ (rows at: rowIndex ) max: [ :cell | cell asTextMorph height ]
+]
+
+{ #category : #sorting }
+MicRichTextTableDataSource >> sortElements: aSortFunction [
+	"This method should sort the elements of the datasource using the sort function as parameter."
+
+	^ self
+]
+
+{ #category : #sorting }
+MicRichTextTableDataSource >> unsortElements [
+	"This method should return the elements in their initial state."
+
+	^ self
+]
+
+{ #category : #'as yet unclassified' }
+MicRichTextTableDataSource >> widthOfText: txt [
+	|width|
+	width := ((txt fontAt: 1) widthOfStringOrText: txt).
+	1 to: txt size do: [ :index | 
+		(txt at: index) = (Character value: 1)
+			ifTrue: [ width := width + 
+				((txt attributesAt: index) detect: [:att| att class = TextAnchor]) anchoredMorph width.
+					 ]
+		 ].
+	^width
+]


### PR DESCRIPTION
This should implement a discount version of table rendering.
It create a morph table and render it as a form.

Example:
```smalltalk
src := '
Yay, rendering tables in rich text

| AAA | $B_j$ | _CCC_ |
|---|---|---|
|![](https://pharo.org/web/files/pharo-logo-small.png)|**bar**| stuff|
|$a^{b^x}$| xxxx |$\frac{a+b}{c+z}$|

That is just awesome
'.

MicRichTextComposer microdownAsRichText: src.
```
