### PR TITLE
Dev baseline did not load Microdown-RichTextComposer-Tests.

### DIFF
--- a/src/BaselineOfMicrodownDev/BaselineOfMicrodownDev.class.st
+++ b/src/BaselineOfMicrodownDev/BaselineOfMicrodownDev.class.st
@@ -27,6 +27,8 @@ BaselineOfMicrodownDev >> baseline: spec [
 				
 			package: #'Microdown-RichTextComposer'
 				with: [ spec requires: #( #Microdown ) ];
+			package: #'Microdown-RichTextComposer-Tests'
+				with: [ spec requires: #( #'Microdown-RichTextComposer' ) ];
 
 			package: #'Microdown-Transformer'
 				with: [ spec requires: #( #Microdown ) ];


### PR DESCRIPTION
The tests were added to the regular baseline, but forgotten in the dev version.