### PR TITLE
Fixes #277.

### DIFF
--- a/src/Microdown-Tests/MicroDownParserTest.class.st
+++ b/src/Microdown-Tests/MicroDownParserTest.class.st
@@ -576,6 +576,20 @@ this is a code block
 	self assert: mic children second body equals: 'this is a code block'
 ]
 
+{ #category : #'tests - table' }
+MicrodownParserTest >> testPipeEscape [
+
+	| tableBlock firstElementOfSecondRowAsString|
+	tableBlock := (parser parse: '
+|foo|bar|
+|12\|3|456|') children first.
+	"Extract the text node"
+	firstElementOfSecondRowAsString := tableBlock rows second first.
+	"now get to the actual string stored there"
+	firstElementOfSecondRowAsString := firstElementOfSecondRowAsString first substring.
+	self assert: firstElementOfSecondRowAsString equals: '12|3'
+]
+
 { #category : #'tests - breaking class comments' }
 MicrodownParserTest >> testRBPatternVariableNode [
 	| paragraph1 paragraph2 paragraph3 |

--- a/src/Microdown/MicTableBlock.class.st
+++ b/src/Microdown/MicTableBlock.class.st
@@ -83,8 +83,13 @@ MicTableBlock >> extractLine: line [
 		| something | something | 
 		or 
 		| something | something"
+	| unicodeReplacementCharacter |
 		
-		^ (line findBetweenSubstrings: #($|)) collect: [ :each | each trim ]
+	"allow pipe symbols to be written as \|"
+	unicodeReplacementCharacter := 16rFFFD asCharacter asString. "By definition this do not appear in any input"
+	 
+	^ ((line copyReplaceAll: '\|' with: unicodeReplacementCharacter) findBetweenSubstrings: '|') 
+			collect: [ :each | (each copyReplaceAll: unicodeReplacementCharacter with: '|') trim]
 		
 				
 		


### PR DESCRIPTION
Allowed pipe `|` to be escaped in tables using `\|`. Also included a test to support it.