### PR TITLE
Fixes #72 - Browsing comment of RBPatternVariableNode raises a syntax Error?

### DIFF
--- a/src/Microdown-RichTextComposer-Tests/MicCodeSemanticActionTest.class.st
+++ b/src/Microdown-RichTextComposer-Tests/MicCodeSemanticActionTest.class.st
@@ -147,6 +147,15 @@ MicCodeSemanticActionTest >> testReferenceToNonExistingClass [
 ]
 
 { #category : #'test - bogus entry' }
+MicCodeSemanticActionTest >> testScannerShouldNotFail [
+
+	self deny: (self semanticActionClass from: 'half"baked') hasEntity.
+	self deny: (self semanticActionClass from: '') hasEntity.
+	self deny: (self semanticActionClass from: 'half"baked') hasEntity.
+	self deny: (self semanticActionClass from: 16rFFFD asCharacter asString) hasEntity.
+]
+
+{ #category : #'test - bogus entry' }
 MicCodeSemanticActionTest >> testTwoBogusElements [
 
 	self assert:

--- a/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
+++ b/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
@@ -467,7 +467,6 @@ MicRichTextComposer class >> rawImageFrom: aURL [
 		
 ]
 
-
 { #category : #'images internal' }
 MicRichTextComposer class >> rawImageFromFile: aFileRef [
 	^ aFileRef binaryReadStreamDo: [ :stream | ImageReadWriter formFromStream: stream ] 

--- a/src/Microdown-RichTextComposer/MicSemanticAction.class.st
+++ b/src/Microdown-RichTextComposer/MicSemanticAction.class.st
@@ -31,7 +31,9 @@ Class {
 
 { #category : #'instance creation' }
 MicSemanticAction class >> from: aString [ 
-	^ self fromTokens: (RBScanner scanTokens: aString)
+	| contents |
+	contents := ((RBScanner on: (ReadStream on: aString) errorBlock: [#()]) contents).
+	^ self fromTokens: (contents collect: #value)
 ]
 
 { #category : #'instance creation' }

--- a/src/Microdown-RichTextComposer/MicSemanticAction.class.st
+++ b/src/Microdown-RichTextComposer/MicSemanticAction.class.st
@@ -33,7 +33,7 @@ Class {
 MicSemanticAction class >> from: aString [ 
 	| contents |
 	contents := ((RBScanner on: (ReadStream on: aString) errorBlock: [#()]) contents).
-	^ self fromTokens: (contents collect: #value)
+	^ self fromTokens: (contents collect: [:e | e value])
 ]
 
 { #category : #'instance creation' }
@@ -51,7 +51,7 @@ MicSemanticAction >> computeEntity [
 		"
 	| size |
 	size := tokens size.
-	size > 4 ifTrue: [  ^ self ].
+	size > 4 ifTrue: [ ^ self ].
 	size = 0 ifTrue: [ ^ self ].
 	"either 'Point' for a class or #'''System-Caching''' for a package"
 	size = 1 


### PR DESCRIPTION
In addition I feel it fixes https://github.com/pillar-markup/Microdown/issues/276#issuecomment-962587695.