### PR TITLE
318 ci is no longer green

### DIFF
--- a/src/BaselineOfMicrodown/BaselineOfMicrodown.class.st
+++ b/src/BaselineOfMicrodown/BaselineOfMicrodown.class.st
@@ -12,7 +12,14 @@ Class {
 BaselineOfMicrodown >> baseline: spec [
 
 	<baseline>
-	spec for: #common do: [ 
+	spec for: #common do: [
+		spec
+			baseline: 'PillarCore'
+			with: [
+				spec  
+					loads: #('Pillar-Core');
+					repository: 'github://pillar-markup/pillar'
+			].
 		spec
 			package: #Microdown;
 			package: #'Microdown-Tests'

--- a/src/BaselineOfMicrodown/BaselineOfMicrodown.class.st
+++ b/src/BaselineOfMicrodown/BaselineOfMicrodown.class.st
@@ -18,7 +18,7 @@ BaselineOfMicrodown >> baseline: spec [
 			with: [
 				spec  
 					loads: #('Pillar-Core');
-					repository: 'github://pillar-markup/pillar'
+					repository: 'github://pillar-markup/pillar:dev-8'
 			].
 		spec
 			package: #Microdown;

--- a/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
+++ b/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
@@ -44,21 +44,8 @@ Class {
 	#superclass : #MicrodownVisitor,
 	#instVars : [
 		'canvas',
-		'monospaceBackgroundColor',
-		'superscriptColor',
-		'subscriptColor',
-		'annotatedParagraphColor',
-		'annotatedParagraphAnnotationColor',
-		'annotatedParagraphAlignment',
-		'styler'
-	],
-	#classVars : [
-		'CaptureErrors',
-		'HeaderFontSizes',
-		'HeaderFonts',
-		'ImageCache',
-		'NotRendering',
-		'OffLine'
+		'codeStyler',
+		'textStyler'
 	],
 	#category : #'Microdown-RichTextComposer-Composer'
 }


### PR DESCRIPTION
This PR updates the baseline to ensure PillarCore is loaded.
It also reverts MicRichTextComposer to use codeStyler and textStyler