### PR TITLE
Fixes some category naming issues

### DIFF
--- a/src/Microdown/MicBoldFormatBlock.class.st
+++ b/src/Microdown/MicBoldFormatBlock.class.st
@@ -7,23 +7,23 @@ Class {
 	#category : #'Microdown-ModelInline'
 }
 
-{ #category : #utilcaca }
+{ #category : #utilities }
 MicBoldFormatBlock >> accept: aVisitor [
 	^ aVisitor visitBold: self
 ]
 
-{ #category : #utilcaca }
+{ #category : #utilities }
 MicBoldFormatBlock >> closingDelimiter [
 
  	^ MicBoldDelimiter markup
 ]
 
-{ #category : #utilcaca }
+{ #category : #utilities }
 MicBoldFormatBlock >> kind [
 	^ #bold
 ]
 
-{ #category : #utilcaca }
+{ #category : #utilities }
 MicBoldFormatBlock >> openingDelimiter [
 
  	^ MicBoldDelimiter markup

--- a/src/Microdown/MicMicrodownTextualBuilder.class.st
+++ b/src/Microdown/MicMicrodownTextualBuilder.class.st
@@ -438,13 +438,13 @@ MicMicrodownTextualBuilder >> paragraph: aBlock [
 	self newLine
 ]
 
-{ #category : #'private utils' }
+{ #category : #'private utilities' }
 MicMicrodownTextualBuilder >> popPrefix [
 	
 	prefixStack removeLast
 ]
 
-{ #category : #'private utils' }
+{ #category : #'private utilities' }
 MicMicrodownTextualBuilder >> pushPrefix: aString [ 
 	
 	prefixStack addLast: aString

--- a/src/Microdown/MicroDownParser.class.st
+++ b/src/Microdown/MicroDownParser.class.st
@@ -193,25 +193,25 @@ MicroDownParser class >> annotatedParagraphMarkup [
 	^ '!!'
 ]
 
-{ #category : #'markup utils' }
+{ #category : #'markup utilities' }
 MicroDownParser class >> argumentListDelimiter [
 	
 	^ '&'
 ]
 
-{ #category : #'markup utils' }
+{ #category : #'markup utilities' }
 MicroDownParser class >> argumentListEqualsDelimiter [
 	
 	^ '='
 ]
 
-{ #category : #'markup utils' }
+{ #category : #'markup utilities' }
 MicroDownParser class >> argumentListOfFigureStartDelimiter [
 	
 	^ '?'
 ]
 
-{ #category : #'markup utils' }
+{ #category : #'markup utilities' }
 MicroDownParser class >> argumentListStartDelimiter [
 	
 	^ '|'
@@ -276,7 +276,7 @@ MicroDownParser class >> inlineMarkup: aType [
 	^ self inlineMarkups at: aType asSymbol
 ]
 
-{ #category : #'markup utils' }
+{ #category : #'markup utilities' }
 MicroDownParser class >> inlineMarkups [
 	^ inlineMarkups ifNil: [ 
 		inlineMarkups := Dictionary new.
@@ -362,7 +362,7 @@ MicroDownParser class >> preformattedMarkup [
 	^ '> '
 ]
 
-{ #category : #'markup utils' }
+{ #category : #'markup utilities' }
 MicroDownParser class >> resetInlineMarkups [
 	"self resetInlineMarkups"
 	inlineMarkups := nil


### PR DESCRIPTION
Someone had left a category name 'utilscaca' in the code. Renamed. Also the main Pharo have been pushing for consistent spelling of 'utilities' rather than 'util' or 'utils'. Fixed those also for combined names like 'private utilities'.