### PR TITLE
Fixes #376 speed is becoming an issue

### DIFF
--- a/src/Microdown-RichTextComposer/MicTextStyler.class.st
+++ b/src/Microdown-RichTextComposer/MicTextStyler.class.st
@@ -59,7 +59,7 @@ MicTextStyler >> headerFontSizes [
 MicTextStyler >> headerLevelFont: level [
 	"I return a font annotation to be used with Attributes"
 	headerFonts ifNil: [ self computeHeaderFonts  ].
-	^ headerFonts at: level
+	^ headerFonts at: (level min: 6)
 ]
 
 { #category : #'composer styles' }

--- a/src/Microdown/MicInlineParser.class.st
+++ b/src/Microdown/MicInlineParser.class.st
@@ -47,6 +47,12 @@ MicInlineParser class >> allDelimiters [
 	^ AllDelimiters 
 ]
 
+{ #category : #'class initialization' }
+MicInlineParser class >> initialize [
+	<script>
+	AllDelimiters := KeyBeginSet := nil.
+]
+
 { #category : #accessing }
 MicInlineParser class >> keyBeginSet [
 	KeyBeginSet ifNil: [ KeyBeginSet := (self allDelimiters keys collect: #first) asSet ].

--- a/src/Microdown/MicInlineParser.class.st
+++ b/src/Microdown/MicInlineParser.class.st
@@ -7,7 +7,6 @@ Class {
 	#instVars : [
 		'openersStack',
 		'result',
-		'allDelimiters',
 		'index',
 		'string',
 		'incrementation',
@@ -17,8 +16,13 @@ Class {
 		'closer',
 		'correctSubstring',
 		'correctURL',
+		'delimiterClass',
 		'keys',
-		'delimiterClass'
+		'allDelimiters'
+	],
+	#classVars : [
+		'AllDelimiters',
+		'KeyBeginSet'
 	],
 	#pools : [
 		'MicroSharedPool'
@@ -27,8 +31,26 @@ Class {
 }
 
 { #category : #accessing }
-MicInlineParser >> abstractDelimiterClass [
+MicInlineParser class >> abstractDelimiterClass [
 	^ MicAbstractDelimiter
+]
+
+{ #category : #accessing }
+MicInlineParser class >> allDelimiters [
+	AllDelimiters ifNil: [ 
+		AllDelimiters := Dictionary new.
+		self abstractDelimiterClass subclasses 
+			select: [ :subclass | subclass isActive ]
+			thenDo: [ :subclass | AllDelimiters 
+										at: subclass markup 
+										put: subclass ]].
+	^ AllDelimiters 
+]
+
+{ #category : #accessing }
+MicInlineParser class >> keyBeginSet [
+	KeyBeginSet ifNil: [ KeyBeginSet := (self allDelimiters keys collect: #first) asSet ].
+	^ KeyBeginSet
 ]
 
 { #category : #'handle basic text' }
@@ -72,7 +94,7 @@ MicInlineParser >> addInlineBlock: indexOfAssociateOpener [
 
 { #category : #accessing }
 MicInlineParser >> allDelimiters [
-	^ allDelimiters
+	^ allDelimiters 
 ]
 
 { #category : #process }
@@ -123,7 +145,7 @@ MicInlineParser >> delimiterFoundProcess [
 
 { #category : #actions }
 MicInlineParser >> identifyMarkupFor: aString [
-
+	(self class keyBeginSet includes: aString first) ifFalse: [ ^self ].
 	keys do: [ :key |
 		(aString beginsWith: key) ifTrue: [ 
 			incrementation := key size.
@@ -156,12 +178,7 @@ MicInlineParser >> initialize [
 
 { #category : #initialization }
 MicInlineParser >> initializeDelimiters [
-	allDelimiters := Dictionary new.
-	self abstractDelimiterClass subclasses 
-		select: [ :subclass | subclass isActive ]
-		thenDo: [ :subclass | allDelimiters 
-										at: subclass markup 
-										put: subclass ].
+	allDelimiters := self class allDelimiters.
 	keys := allDelimiters keys.
 ]
 
@@ -362,18 +379,20 @@ MicInlineParser >> pushNewOpener [
 { #category : #actions }
 MicInlineParser >> read: aString [
 	| next |
-	incrementation := 1.
-	aString ifEmpty: [ ^ self resultProcess ].
-	self identifyMarkupFor: aString.
-	"this is stupid to iterate all. We can stop as soon as we found one. "
+	next := aString.
+	[ next isEmpty ] whileFalse: [ 
+		incrementation := 1.
+		self identifyMarkupFor: next.
+		"this is stupid to iterate all. We can stop as soon as we found one. "
 
-	aString first = $\ ifTrue: [ 
-		incrementation := incrementation + 1 ].
-	self indexIncrement: incrementation.
-	aString size > incrementation 
-		ifTrue: [ next := (aString allButFirst: incrementation)]
-		ifFalse: [next := ''].
-	^ self read: next.
+		next first = $\ ifTrue: [ 
+			incrementation := incrementation + 1 ].
+		self indexIncrement: incrementation.
+		next := next size > incrementation 
+			ifTrue: [ (next allButFirst: incrementation)]
+			ifFalse: [''].
+	].
+	^ self resultProcess
 ]
 
 { #category : #process }


### PR DESCRIPTION
## Parsing
Using the contents of `gen_refactoringframework.md`, and the call `Microdown parse: contents`.
Timing using:
```smalltalk
((1 to: 25) collect: [:dummy | Time microsecondsToRun: [Microdown parse: contents]]) min
```

Initial result: 305,196 µs
read: non-recursive: 292,053 µs (non-significant - kudos Pharo!)
making identifyMarkupFor: check only in relevant cases : 53,211 µs
Speedup: 5+ times.

Other speedup might be possible, but using `TimeProfiler` there are no 
obviously bad code to attack (few percent gain).

## Rendering
Sadly the `TimeeProfiler` points to `SHTextStyler`, the code styler for pharo.
Rendering all code as raw text gives a speedup on rendering time of 8+ times.
