### PR TITLE
- Now HTMLWriter is a subclass of documentWriter.

### DIFF
--- a/src/Microdown-HTMLExporter/MicHTMLWriter.class.st
+++ b/src/Microdown-HTMLExporter/MicHTMLWriter.class.st
@@ -4,10 +4,7 @@ We should rewrite it once the templatedWriter is working.
 "
 Class {
 	#name : #MicHTMLWriter,
-	#superclass : #MicrodownVisitor,
-	#instVars : [
-		'canvas'
-	],
+	#superclass : #MicDocumentWriter,
 	#category : #'Microdown-HTMLExporter'
 }
 
@@ -15,11 +12,6 @@ Class {
 MicHTMLWriter >> canvasClass [
 
 	^ MicHTMLCanvas
-]
-
-{ #category : #accessing }
-MicHTMLWriter >> contents [ 
-	^ canvas contents
 ]
 
 { #category : #converting }
@@ -66,13 +58,6 @@ MicHTMLWriter >> languageForScript: aScript [
 	^ aScript language isSpecified
 		  ifTrue: [ aScript language ]
 		  ifFalse: [ self configuration defaultScriptLanguage ]
-]
-
-{ #category : #initialization }
-MicHTMLWriter >> usedNewLine [
-	"Return the encoded new line. Useful for tests."
-	
-	^ canvas stream usedNewLine
 ]
 
 { #category : #visiting }

--- a/src/Microdown-LaTeXExporter/MicDocumentWriter.class.st
+++ b/src/Microdown-LaTeXExporter/MicDocumentWriter.class.st
@@ -3,7 +3,6 @@ Class {
 	#superclass : #MicrodownVisitor,
 	#instVars : [
 		'canvas',
-		'stream',
 		'nbListTab',
 		'writingRaw'
 	],
@@ -13,20 +12,21 @@ Class {
 { #category : #accessing }
 MicDocumentWriter >> canvasClass [ 
 
-	^ MicHTMLCanvas
+	^ self subclassResponsibility 
 ]
 
 { #category : #writing }
 MicDocumentWriter >> contents [
 
-	^ stream contents
+	^ canvas contents
 ]
 
 { #category : #initialization }
-MicDocumentWriter >> initialize [ 
+MicDocumentWriter >> initialize [
+	| stream2 |
 	super initialize.
-	stream := MicOutputStream new setStream: (WriteStream on: (String new: 1000)).
-	canvas := self canvasClass on: stream.
+	stream2 := MicOutputStream new setStream: (WriteStream on: (String new: 1000)).
+	canvas := self canvasClass on: stream2.
 	writingRaw := false.
 	nbListTab := -1
 ]
@@ -35,7 +35,7 @@ MicDocumentWriter >> initialize [
 MicDocumentWriter >> usedNewLine [
 	"Return the encoded new line. Useful for tests."
 	
-	^ stream usedNewLine
+	^ canvas stream usedNewLine
 ]
 
 { #category : #writing }

--- a/src/Microdown-LaTeXExporter/MicLaTeXWriter.class.st
+++ b/src/Microdown-LaTeXExporter/MicLaTeXWriter.class.st
@@ -49,11 +49,6 @@ MicLaTeXWriter >> chapterTemplateName [
 	^ 'latexChapterTemplate'
 ]
 
-{ #category : #accessing }
-MicLaTeXWriter >> contents [
-	^ stream contents
-]
-
 { #category : #helpers }
 MicLaTeXWriter >> createLinkToLabelWithAlias: anInternalLink [
 	canvas command


### PR DESCRIPTION
- Clean contents/stream in writer hierarchies.
- remove unnecessary stream instance variables. All tests green from here.