### PR TITLE
Fixes #388. TextComposer should be able to do inputFile 

### DIFF
--- a/src/Microdown-RichTextComposer-Tests/MicRichTextComposerTest.class.st
+++ b/src/Microdown-RichTextComposer-Tests/MicRichTextComposerTest.class.st
@@ -362,6 +362,16 @@ MicRichTextComposerTest >> testHeaderLevel6 [
 		include: self headerLevel6
 ]
 
+{ #category : #tests }
+MicRichTextComposerTest >> testInputfile [
+
+	| source result |
+	source := '{!inputFile|path=comment://class/MicRichTextComposerTest!}'.
+	result := (self richTextForString: source) asString trim.
+	self assert: (result beginsWith: 'MicRichTextComposerTest').
+	self assert: (result includesSubstring: 'This class contains tests')
+]
+
 { #category : #'skipped tests' }
 MicRichTextComposerTest >> testItalicFormat [
 

--- a/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
+++ b/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
@@ -413,6 +413,14 @@ MicRichTextComposer >> visitHorizontalLine: anHorizontalLine [
 	canvas newLine.	
 ]
 
+{ #category : #visiting }
+MicRichTextComposer >> visitInputFile: inputFileBloc [
+	| inputRef includedText |
+	inputRef := inputFileBloc reference.
+	includedText := Microdown asRichText: inputRef loadMicrodown.
+	canvas << (textStyler postTextTreatment: includedText )
+]
+
 { #category : #'visiting -  format' }
 MicRichTextComposer >> visitItalic: anObject [
 	canvas 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17723745/166420366-8c266416-0763-47e5-b987-6d9a2d16de24.png)
