### PR TITLE
Fixes #398 mic pharo image resource reference only handles images

### DIFF
--- a/src/Microdown-RichTextComposer-Tests/MicRichTextComposerTest.class.st
+++ b/src/Microdown-RichTextComposer-Tests/MicRichTextComposerTest.class.st
@@ -362,6 +362,16 @@ MicRichTextComposerTest >> testHeaderLevel6 [
 		include: self headerLevel6
 ]
 
+{ #category : #tests }
+MicRichTextComposerTest >> testInputfile [
+
+	| source result |
+	source := '{!inputFile|path=comment://class/MicRichTextComposerTest!}'.
+	result := (self richTextForString: source) asString trim.
+	self assert: (result beginsWith: 'MicRichTextComposerTest').
+	self assert: (result includesSubstring: 'This class contains tests')
+]
+
 { #category : #'skipped tests' }
 MicRichTextComposerTest >> testItalicFormat [
 

--- a/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
+++ b/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
@@ -413,6 +413,14 @@ MicRichTextComposer >> visitHorizontalLine: anHorizontalLine [
 	canvas newLine.	
 ]
 
+{ #category : #visiting }
+MicRichTextComposer >> visitInputFile: inputFileBloc [
+	| inputRef includedText |
+	inputRef := inputFileBloc reference.
+	includedText := Microdown asRichText: inputRef loadMicrodown.
+	canvas << (textStyler postTextTreatment: includedText )
+]
+
 { #category : #'visiting -  format' }
 MicRichTextComposer >> visitItalic: anObject [
 	canvas 

--- a/src/Microdown-Tests/MicPharoImageResourceReferenceTest.class.st
+++ b/src/Microdown-Tests/MicPharoImageResourceReferenceTest.class.st
@@ -4,6 +4,11 @@ Class {
 	#category : #'Microdown-Tests-Core'
 }
 
+{ #category : #'test support' }
+MicPharoImageResourceReferenceTest class >> microdownProducingMethod [
+	^ Microdown parse: 'I am **bold**'
+]
+
 { #category : #tests }
 MicPharoImageResourceReferenceTest >> testIcon [
 
@@ -12,4 +17,15 @@ MicPharoImageResourceReferenceTest >> testIcon [
 	image := uri loadImage.
 
 	self assert: image equals: (Object iconNamed: #info)
+]
+
+{ #category : #tests }
+MicPharoImageResourceReferenceTest >> testMicrodownImport [
+
+	| ref doc |
+	ref := 'pharo:///MicPharoImageResourceReferenceTest/microdownProducingMethod'
+		asMicResourceReference.
+	doc := ref loadMicrodown.
+
+	self assert: doc children notEmpty
 ]

--- a/src/Microdown/MicPharoImageResourceReference.class.st
+++ b/src/Microdown/MicPharoImageResourceReference.class.st
@@ -23,19 +23,28 @@ MicPharoImageResourceReference class >> handlesUriScheme: scheme [
 	^ scheme = 'pharo'
 ]
 
-{ #category : #'accessing - resources' }
+{ #category : #accessing }
+MicPharoImageResourceReference >> binaryReadStream [
+	"I am not needed, I implement loadImage directly"
+	^ self shouldBeImplemented
+]
+
+{ #category : #accessing }
+MicPharoImageResourceReference >> contents [
+	"I am not needed, I implement loadMicrodown directly"
+	^ self shouldBeImplemented
+]
+
+{ #category : #loading }
 MicPharoImageResourceReference >> loadImage [
+	"Assume the method just returns a form"
+	^ self perform
+]
 
-	"I assume the uri to have the form: 'pharo:///class/selector:/arg1/arg2"
-
-	| class selector size args |
-	class := (self class environment at: uri segments first asSymbol)
-		         class.
-	selector := uri segments second asSymbol.
-	args := (size := uri segments size) > 2
-		        ifTrue: [ (uri segments copyFrom: 3 to: size) asArray ]
-		        ifFalse: [ #(  ) ].
-	^ class perform: selector withArguments: args
+{ #category : #loading }
+MicPharoImageResourceReference >> loadMicrodown [
+	"Assume the method just returns a form"
+	^ self perform
 ]
 
 { #category : #private }

--- a/src/Microdown/MicPharoImageResourceReference.class.st
+++ b/src/Microdown/MicPharoImageResourceReference.class.st
@@ -37,3 +37,15 @@ MicPharoImageResourceReference >> loadImage [
 		        ifFalse: [ #(  ) ].
 	^ class perform: selector withArguments: args
 ]
+
+{ #category : #private }
+MicPharoImageResourceReference >> perform [
+	"I assume the uri to have the form: 'pharo:///class/selector:/arg1/arg2"
+	| class selector size args |
+	class := self class environment at: uri segments first asSymbol.
+	selector := uri segments second asSymbol.
+	args := (size := uri segments size) > 2
+		        ifTrue: [ (uri segments copyFrom: 3 to: size) asArray ]
+		        ifFalse: [ #(  ) ].
+	^ class perform: selector withArguments: args
+]


### PR DESCRIPTION
Enabled the loadMicrodown method, allowing microdown: `{!inputFile|path=pharo:/Class/method/arg1/arg2!}`, that is to include computed microdown to be input into a microdown document. 
