### PR TITLE
Fixes #361 Better align environments and extensions

### DIFF
--- a/src/Microdown-Tests/MicColumnsBlockTest.class.st
+++ b/src/Microdown-Tests/MicColumnsBlockTest.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #MicColumnsBlockTest,
-	#superclass : #MicAnnotationSubclassTest,
+	#superclass : #TestCase,
 	#category : #'Microdown-Tests-Extensions'
 }
 

--- a/src/Microdown-Tests/MicMathBlockExtensionForTest.class.st
+++ b/src/Microdown-Tests/MicMathBlockExtensionForTest.class.st
@@ -1,0 +1,13 @@
+"
+I am used in the MathBlockExtensionTest
+"
+Class {
+	#name : #MicMathBlockExtensionForTest,
+	#superclass : #MicMathBlock,
+	#category : #'Microdown-Tests-Extensions'
+}
+
+{ #category : #accessing }
+MicMathBlockExtensionForTest class >> tag [
+	^#mathBlockExtentionTest
+]

--- a/src/Microdown-Tests/MicMathBlockExtensionTest.class.st
+++ b/src/Microdown-Tests/MicMathBlockExtensionTest.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : #MicMathBlockExtensionTest,
+	#superclass : #TestCase,
+	#category : #'Microdown-Tests-Extensions'
+}
+
+{ #category : #tests }
+MicMathBlockExtensionTest >> testExtension [
+	
+	| doc extension|
+	doc := Microdown parse:  
+'
+&mathBlockExtentionTest
+stuff which is left for the extension to handle
+&'.
+	self assert: doc children size equals: 1.
+	extension := doc children first.
+	self assert: extension class equals: MicMathBlockExtensionForTest.
+	self assert: extension body equals: 'stuff which is left for the extension to handle'
+]

--- a/src/Microdown/MicAnnotationBlock.class.st
+++ b/src/Microdown/MicAnnotationBlock.class.st
@@ -22,22 +22,25 @@ Class {
 
 { #category : #constructor }
 MicAnnotationBlock class >> from: aStartInteger to: anEndInteger withSubstring: aString withChildren: aChildren [
-	
-	| splitter tag klass |
-	splitter := MicArgumentsSplitter split: aString defaultArg: #annotationKind defaultValue: 'Me'.
-	tag := splitter defaultValue trimBoth.
-	
-	klass := self subclasses detect: [ :each | each tag = tag ] ifNone: [ self ].
 
-	^ klass new 
-		start: aStartInteger; 
-		end: anEndInteger; 
-		substring: aString; 
-		children: aChildren; 
-		arguments: splitter;
-		cleanSubstring; 
-		closeMe; 
-		yourself.	
+	| splitter tag extensionClass |
+	splitter := MicArgumentsSplitter
+		            split: aString
+		            defaultArg: #annotationKind
+		            defaultValue: 'Me'.
+	tag := splitter defaultValue trimBoth.
+
+	extensionClass := self extensionClassFor: tag.
+
+	^ extensionClass new
+		  start: aStartInteger;
+		  end: anEndInteger;
+		  substring: aString;
+		  children: aChildren;
+		  arguments: splitter;
+		  cleanSubstring;
+		  closeMe;
+		  yourself
 ]
 
 { #category : #accessing }

--- a/src/Microdown/MicElement.class.st
+++ b/src/Microdown/MicElement.class.st
@@ -11,6 +11,12 @@ Class {
 	#category : #'Microdown-Model'
 }
 
+{ #category : #utilities }
+MicElement class >> extensionClassFor: tag [
+	"I am a utility method used in extension blocks to find the right subclass to instantiate"
+	^ self subclasses detect: [ :each | each tag = tag ] ifNone: [ self ]
+]
+
 { #category : #properties }
 MicElement >> hasProperty: aKey [
 	"Answer whether there is a property named aKey."

--- a/src/Microdown/MicEnvironmentBlock.class.st
+++ b/src/Microdown/MicEnvironmentBlock.class.st
@@ -71,16 +71,15 @@ Class {
 
 { #category : #public }
 MicEnvironmentBlock class >> alternateBlockClassFor: line [
+
 	"If there is one subclass with the corresponding tag, returns it, else resturn the current class."
-	"line is of the form <?slide|title=Schedule"
-	
+	"line is of the form <!slide|title=Schedule"
 	"We know that the two first characters are <? else we would be invoked"
+
 	| tag |
-	tag := ((line allButFirst: 2) copyUpTo: $|) trimBoth.
-	^ self allSubclasses detect: [ :each | each tag = tag ] ifNone: [ self ]
-	
-	
-	
+	tag := ((line allButFirst: EnvironmentOpeningBlockMarkup size) 
+		        copyUpTo: $|) trimBoth.
+	^ self extensionClassFor: tag
 ]
 
 { #category : #visiting }

--- a/src/Microdown/MicMathBlock.class.st
+++ b/src/Microdown/MicMathBlock.class.st
@@ -25,6 +25,19 @@ Class {
 	#category : #'Microdown-Model'
 }
 
+{ #category : #public }
+MicMathBlock class >> alternateBlockClassFor: line [
+
+	"If there is one subclass with the corresponding tag, returns it, else resturn the current class."
+	"line is of the form <!slide|title=Schedule"
+	"We know that the two first characters are <? else we would be invoked"
+
+	| tag |
+	tag := ((line allButFirst: MathOpeningBlockMarkup size) 
+		        copyUpTo: $|) trimBoth.
+	^ self extensionClassFor: tag
+]
+
 { #category : #visiting }
 MicMathBlock >> accept: aVisitor [ 
  	^ aVisitor visitMath: self


### PR DESCRIPTION
This PR adds extension mechanism to MathBlock `&` similar to environments. 

The original three bullets of #361:
- The && block could have an extension name + arguments
- The environment is not rendered by many rendereds such as github. Replace it by <! !> or make it an alias to it (fixed by #362)
- annotation ?{asd}? => {!asd?!} (fixed by #363)

have all been addressed now