### PR TITLE
Fixes #402 mic rich text composer does not handle raw

### DIFF
--- a/src/Microdown-RichTextComposer-Tests/MicRichTextComposerTest.class.st
+++ b/src/Microdown-RichTextComposer-Tests/MicRichTextComposerTest.class.st
@@ -548,6 +548,22 @@ MicRichTextComposerTest >> testQuoteBlock [
 	self deny: (richText asString findString: 'foo') equals: 0
 ]
 
+{ #category : #tests }
+MicRichTextComposerTest >> testRaw [
+	| text |
+	text := Microdown asRichText: '{{**not bold**}}'.
+	self assert: text asString trim equals: '**not bold**'.
+]
+
+{ #category : #tests }
+MicRichTextComposerTest >> testRawNewLinesPreserved [
+	| text |
+	text := Microdown asRichText: '{{**not 
+bold**}}'.
+	self assert: text asString trim equals: '**not
+bold**'.
+]
+
 { #category : #'skipped tests' }
 MicRichTextComposerTest >> testStrikethroughFormat [ 
 	| source runs richText |

--- a/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
+++ b/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
@@ -529,6 +529,12 @@ MicRichTextComposer >> visitQuote: aQuote [
 	canvas newLine
 ]
 
+{ #category : #'visiting - inline elements' }
+MicRichTextComposer >> visitRaw: aRawFormat [
+
+	canvas << aRawFormat substring asText.
+]
+
 { #category : #'visiting -  format' }
 MicRichTextComposer >> visitStrike: anObject [
 

--- a/src/Microdown-RichTextComposer/MicroDownParser.extension.st
+++ b/src/Microdown-RichTextComposer/MicroDownParser.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #MicrodownParser }
 
 { #category : #'*Microdown-RichTextComposer' }
-MicrodownParser classSide >> convertToRichText: aString [
+MicrodownParser class >> convertToRichText: aString [
 	^ MicRichTextComposer new visit: (self new parse: aString)
 ]


### PR DESCRIPTION
FIxes #402
Just copies the raw body onto the output canvas. Added a few tests in addition