### PR TITLE
Fixes #391 - failing MicFileResourceReference test on windows

### DIFF
--- a/src/Microdown/MicFileResourceReference.class.st
+++ b/src/Microdown/MicFileResourceReference.class.st
@@ -29,7 +29,7 @@ Class {
 MicFileResourceReference class >> fromFileRef: aFileReference [
 	"return an instance of me which references aFileReference"
 	^ self new
-		uri: ('file://',aFileReference pathString) asZnUrl;
+		uri: aFileReference asZnUrl;
 		filesystem: aFileReference fileSystem 
 ]
 


### PR DESCRIPTION
It would be useful with a windows machine in the CI - dreams are free...