### PR TITLE
Fixes: 442 table does not work well with nested  in monospace 

### DIFF
--- a/src/Microdown-Tests/MicInlineParserTest.class.st
+++ b/src/Microdown-Tests/MicInlineParserTest.class.st
@@ -166,6 +166,21 @@ MicInlineParserTest >> testEscapeCharacterWithNoCharacterAfter [
 		assert: res first substring equals: '\'
 ]
 
+{ #category : #tests }
+MicInlineParserTest >> testEscapeEncode [
+	| roundTrip |
+	self assert: (MicInlineParser escapeEncode: '') equals: ''.
+	self assert: (MicInlineParser escapeEncode: 'abc') equals: 'abc'.
+	self assert: (MicInlineParser escapeEncode: 'abc\') equals: 'abc\'.
+	self assert: (MicInlineParser escapeEncode: '\') equals: '\'.
+	roundTrip := [ :str | MicInlineParser escapeDecode: (MicInlineParser escapeEncode: str) ].
+	self assert: (roundTrip value: 'aa\\bb') equals: 'aa\bb'.
+	self assert: (roundTrip value: '\aa\\bb') equals: 'aa\bb'.
+	self assert: (roundTrip value: 'aa\`bb') equals: 'aa`bb'.
+	self assert: (roundTrip value: 'aa\@b@b') equals: 'aa@b@b'.
+	self assert: (roundTrip value: '\\') equals: '\'.
+]
+
 { #category : #'tests - formats' }
 MicInlineParserTest >> testEscapeMonospace [
 	"When isEvaluated class method returns false, like monospace's case, inline inside shoudn't be evaluated"
@@ -175,6 +190,18 @@ MicInlineParserTest >> testEscapeMonospace [
 	self
 		assert: res second substring equals: '`monospace`'.
 	self assert: res second class equals: MicMonospaceFormatBlock
+]
+
+{ #category : #tests }
+MicInlineParserTest >> testEscapeReEscape [
+	| roundTrip |
+	roundTrip := [ :str :keep | 
+		MicInlineParser escapeReescape: (MicInlineParser escapeEncode: str)  except:  keep ].
+	
+	self assert: (roundTrip value: '' value: 'aa') equals: ''.
+	self assert: (roundTrip value: 'abc' value: '') equals: 'abc'.
+	self assert: (roundTrip value: 'aa\\bb' value: '' ) equals: 'aa\\bb'.
+	self assert: (roundTrip value: '\aa\\bb' value: 'a') equals: 'aa\\bb'.
 ]
 
 { #category : #'tests - escape' }

--- a/src/Microdown/MicAnnotationBlock.class.st
+++ b/src/Microdown/MicAnnotationBlock.class.st
@@ -38,8 +38,8 @@ MicAnnotationBlock class >> from: aStartInteger to: anEndInteger withSubstring: 
 		  substring: aString;
 		  children: aChildren;
 		  arguments: splitter;
-		  cleanSubstring;
 		  closeMe;
+		  cleanSubstring;
 		  yourself
 ]
 

--- a/src/Microdown/MicInlineBlockWithUrl.class.st
+++ b/src/Microdown/MicInlineBlockWithUrl.class.st
@@ -35,10 +35,10 @@ MicInlineBlockWithUrl class >> from: aStartInteger to: anEndInteger withKind: aK
 		start: aStartInteger; 
 		end: anEndInteger; 
 		substring: aString; 
-		children: aChildren; 
-		cleanSubstring; 
+		children: aChildren;
 		url: aURL;
 		closeMe; 
+		cleanSubstring; 
 		yourself
 ]
 
@@ -49,10 +49,10 @@ MicInlineBlockWithUrl class >> from: aStartInteger to: anEndInteger withKind: aK
 		end: anEndInteger; 
 		substring: aString; 
 		children: aChildren; 
-		cleanSubstring; 
 		url: aURL;
 		parser: aParser;
 		closeMe; 
+		cleanSubstring; 
 		yourself
 ]
 

--- a/src/Microdown/MicInlineElement.class.st
+++ b/src/Microdown/MicInlineElement.class.st
@@ -23,14 +23,7 @@ Class {
 
 { #category : #constructor }
 MicInlineElement class >> from: aStartInteger to: anEndInteger withSubstring: aString [
-	^ self new 
-		start: aStartInteger; 
-		end: anEndInteger; 
-		substring: aString; 
-		children: Array empty; 
-		cleanSubstring; 
-		closeMe;
-		yourself.	
+	^ self from: aStartInteger to: anEndInteger withSubstring: aString withChildren: Array new
 ]
 
 { #category : #constructor }
@@ -39,9 +32,9 @@ MicInlineElement class >> from: aStartInteger to: anEndInteger withSubstring: aS
 		start: aStartInteger; 
 		end: anEndInteger; 
 		substring: aString; 
-		children: aChildren; 
+		children: aChildren;
+		closeMe;  
 		cleanSubstring; 
-		closeMe; 
 		yourself.	
 ]
 
@@ -67,15 +60,8 @@ MicInlineElement >> childrenPrintOn [
 
 { #category : #operations }
 MicInlineElement >> cleanSubstring [
-	| keepDoubleEscapes res |
 	"remove all \ left by the MicInlineParser - and replace \\ with single \"
-	self substring ifEmpty: [ ^ self ].
-	keepDoubleEscapes := 16rFFFD asCharacter asString.
-	res := self substring copyReplaceAll: '\\' with: keepDoubleEscapes.
-	res last = $\ ifTrue:[res at: res size put: 16rFFFD asCharacter].
-	res := res copyWithoutAll: '\'.
-	res := res copyReplaceAll: keepDoubleEscapes  with: '\'.
-	self substring: res
+	self substring: (MicInlineParser escapeDecode: self substring )
 ]
 
 { #category : #visiting }

--- a/src/Microdown/MicInlineParser.class.st
+++ b/src/Microdown/MicInlineParser.class.st
@@ -455,10 +455,6 @@ MicInlineParser >> read: aString [
 	[ next isEmpty ] whileFalse: [ 
 		incrementation := 1.
 		self identifyMarkupFor: next.
-		"this is stupid to iterate all. We can stop as soon as we found one. "
-
-		next first = $\ ifTrue: [ 
-			incrementation := incrementation + 1 ].
 		self indexIncrement: incrementation.
 		next := next size > incrementation 
 			ifTrue: [ (next allButFirst: incrementation)]
@@ -476,7 +472,7 @@ MicInlineParser >> resultProcess [
 		| startSubstring endSubstring |
 		e substring isEmpty 	
 			ifTrue: [ startSubstring := endSubstring := 1 ]
-			ifFalse: [  	startSubstring := (string indexOfSubCollection: e substring startingAt: e start) max: 1.
+			ifFalse: [  	startSubstring := e start + e openingDelimiter size.
 		endSubstring := startSubstring + e substring size - 1 ].
 		e children: (self insertBasicText: e children from: startSubstring to: endSubstring) ].
 	^ self insertBasicText: result

--- a/src/Microdown/MicInlineParser.class.st
+++ b/src/Microdown/MicInlineParser.class.st
@@ -47,6 +47,63 @@ MicInlineParser class >> allDelimiters [
 	^ AllDelimiters 
 ]
 
+{ #category : #'escape character' }
+MicInlineParser class >> escapeDecode: aString [
+	"I convert all encoded chars back to their original (without the leading escape character)"
+	"My sister method escapeEncode encodes into the format I decode from"
+	| inStream outStream char special |
+	aString ifEmpty: [ ^aString ].
+	special := [ :c | c asInteger between: self magicCharacter  and: self magicCharacter + 65536 ].
+	inStream := ReadStream on: aString.
+	outStream := WriteStream on: String new.
+	[ inStream atEnd ] whileFalse: [ 
+		char := inStream next.
+		(special value: char)
+			ifTrue: [ char := (char asInteger - self magicCharacter ) asCharacter  ].
+		outStream nextPut: char
+	].
+	^ outStream contents
+	
+]
+
+{ #category : #'escape character' }
+MicInlineParser class >> escapeEncode: aString [
+	"I convert all escaped characters (eg '\`' or '\\') into special characters which are not used in Microdown"
+	"My sister method escapeDecode reverts back"
+	| inStream outStream char |
+	aString size <= 1 ifTrue: [ ^aString ].
+	inStream := ReadStream on: aString.
+	outStream := WriteStream on: String new.
+	[ inStream atEnd ] whileFalse: [ 
+		char := inStream next.
+		(char = $\ and: [ inStream atEnd not ]) 
+			ifTrue: [ char := (inStream next asInteger + self magicCharacter) asCharacter  ].
+		outStream nextPut: char
+	].
+	^ outStream contents
+	
+]
+
+{ #category : #'escape character' }
+MicInlineParser class >> escapeReescape: aString except: keep [
+	"I convert all encoded back to escaped chars, except the characters in keep"
+	"My sister method escapeEncode encodes into the format I decode from"
+	| inStream outStream char |
+	aString ifEmpty: [ ^aString ].
+	inStream := ReadStream on: aString.
+	outStream := WriteStream on: String new.
+	[ inStream atEnd ] whileFalse: [ 
+		char := inStream next.
+		(char asInteger between: self magicCharacter  and: self magicCharacter + 65536)
+			ifTrue: [ 
+				char := (char asInteger - self magicCharacter ) asCharacter.  
+				(keep includes: char) ifFalse: [outStream nextPut: $\]] .
+		outStream nextPut: char
+	].
+	^ outStream contents
+	
+]
+
 { #category : #'class initialization' }
 MicInlineParser class >> initialize [
 	<script>
@@ -57,6 +114,14 @@ MicInlineParser class >> initialize [
 MicInlineParser class >> keyBeginSet [
 	KeyBeginSet ifNil: [ KeyBeginSet := (self allDelimiters keys collect: #first) asSet ].
 	^ KeyBeginSet
+]
+
+{ #category : #'escape character' }
+MicInlineParser class >> magicCharacter [
+	"All escaped characters are moved out of range. 
+	The unicode range Private Use Area is used, 
+	see https://en.wikipedia.org/wiki/Private_Use_Areas "
+	^ 16r100000 "Private Use Area-B"
 ]
 
 { #category : #'handle basic text' }
@@ -368,8 +433,8 @@ MicInlineParser >> openerOnlyCase [
 MicInlineParser >> parse: aString [
 
 	aString ifEmpty: [ ^ Array empty ].
-	string := aString.
-	^ self read: aString
+	string := self class escapeEncode: aString.
+	^ self read: string
 ]
 
 { #category : #actions }

--- a/src/Microdown/MicMathInlineBlock.class.st
+++ b/src/Microdown/MicMathInlineBlock.class.st
@@ -40,9 +40,9 @@ MicMathInlineBlock >> accept: aVisitor [
 	^ aVisitor visitMathInline: self
 ]
 
-{ #category : #testing }
+{ #category : #operations }
 MicMathInlineBlock >> cleanSubstring [
-	"overrides to do nothing - super removes backslash, which we should not in latex"
+	self substring: (MicInlineParser escapeReescape: self substring  except: '')
 ]
 
 { #category : #accessing }

--- a/src/Microdown/MicMonospaceFormatBlock.class.st
+++ b/src/Microdown/MicMonospaceFormatBlock.class.st
@@ -8,11 +8,6 @@ Class {
 }
 
 { #category : #testing }
-MicMonospaceFormatBlock class >> cleanSubstring [
-	"does nothing on purpose"
-]
-
-{ #category : #testing }
 MicMonospaceFormatBlock class >> isEvaluated [
 	^ false
 ]
@@ -24,9 +19,7 @@ MicMonospaceFormatBlock >> accept: aVisitor [
 
 { #category : #operations }
 MicMonospaceFormatBlock >> cleanSubstring [
-	| res |
-	res := self substring copyReplaceAll: '\`' with: '`'..
-	self substring: res
+	self substring: (MicInlineParser escapeReescape: self substring except: '`')
 ]
 
 { #category : #internal }

--- a/src/Microdown/MicRawBlock.class.st
+++ b/src/Microdown/MicRawBlock.class.st
@@ -21,9 +21,9 @@ MicRawBlock >> accept: aVisitor [
 	^ aVisitor visitRaw: self
 ]
 
-{ #category : #testing }
+{ #category : #operations }
 MicRawBlock >> cleanSubstring [
-	"overrides to do nothing - super removes backslash, which we should not in raw"
+	self substring: (MicInlineParser escapeReescape: self substring  except: '')
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
### Design criteria:
- The escape character is \
- One can escape any character which is part of a Microdown delimiter
- Escaping and Descaping should be handled uniformly across all inline blocks
- No paragraph block should start with the escape charager (true now) - this means that an escaped paragraph block starter will cause the paragraph to be Paragraph, and the escape will then be part of the inline parser (as intended).

### Algorithm
- MicInlineParser>>#parse: will convert all \X | X in Delimiter to characters in Unicode PUB 16 area, more precisely U10A000 + X asInteger.
- Notice, the conversion happens before parsing the inner text, so there is no change of text length.
- MicInlineElement>>cleanString converts all U10Axxx to original characters.
