### PR TITLE
Fixes #470 integration is failing 

### DIFF
--- a/src/Microdown-DocumentBrowser-Tests/MicGitHubRessourceReferenceTest.class.st
+++ b/src/Microdown-DocumentBrowser-Tests/MicGitHubRessourceReferenceTest.class.st
@@ -4,9 +4,6 @@ A MicGitHubRessourceReferenceTest is a test class for testing the behavior of Mi
 Class {
 	#name : #MicGitHubRessourceReferenceTest,
 	#superclass : #TestCase,
-	#instVars : [
-		'savedCache'
-	],
 	#category : #'Microdown-DocumentBrowser-Tests-ResourceModel'
 }
 

--- a/src/Microdown-DocumentBrowser/MicOpenDocumentBrowserCommand.class.st
+++ b/src/Microdown-DocumentBrowser/MicOpenDocumentBrowserCommand.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #executing }
 MicOpenDocumentBrowserCommand >> execute [
-	self context halt
+	"to be done"
 ]
 
 { #category : #initialization }

--- a/src/Microdown-HTMLExporter-Tests/MicCSSProviderTest.class.st
+++ b/src/Microdown-HTMLExporter-Tests/MicCSSProviderTest.class.st
@@ -7,14 +7,14 @@ Class {
 	#category : #'Microdown-HTMLExporter-Tests'
 }
 
-{ #category : #test }
+{ #category : #tests }
 MicCSSProviderTest >> testLibraryNames [
 
 	self assert: (MicCSSProvider libraryNames isKindOf: Collection).
 	self assert: (MicCSSProvider libraryNames allSatisfy: #isString)
 ]
 
-{ #category : #test }
+{ #category : #tests }
 MicCSSProviderTest >> testNamed [
 	
 	| tufte |

--- a/src/Microdown-HTMLExporter-Tests/MicHTMLBrushTest.class.st
+++ b/src/Microdown-HTMLExporter-Tests/MicHTMLBrushTest.class.st
@@ -25,7 +25,7 @@ MicHTMLBrushTest >> tag [
 	^ tag
 ]
 
-{ #category : #test }
+{ #category : #tests }
 MicHTMLBrushTest >> testName [
 
 	tag name: 'prueba'.

--- a/src/Microdown-HTMLExporter-Tests/MicHTMLCanvasTest.class.st
+++ b/src/Microdown-HTMLExporter-Tests/MicHTMLCanvasTest.class.st
@@ -18,7 +18,7 @@ MicHTMLCanvasTest >> setUp [
 
 ]
 
-{ #category : #test }
+{ #category : #tests }
 MicHTMLCanvasTest >> testTag [
 	
 	self assert: (canvas tag isKindOf: MicHTMLTag)

--- a/src/Microdown-HTMLExporter-Tests/MicHTMLTagTest.class.st
+++ b/src/Microdown-HTMLExporter-Tests/MicHTMLTagTest.class.st
@@ -26,14 +26,14 @@ MicHTMLTagTest >> testAddArguments [
 
 ]
 
-{ #category : #test }
+{ #category : #tests }
 MicHTMLTagTest >> testClose [
 
 	tag close.
 	self assert: tag contents equals: '>'
 ]
 
-{ #category : #test }
+{ #category : #tests }
 MicHTMLTagTest >> testContents [
 
 	tag 
@@ -43,7 +43,7 @@ MicHTMLTagTest >> testContents [
 	self assert: tag contents equals: '<falop>This is a test</falop>'
 ]
 
-{ #category : #test }
+{ #category : #tests }
 MicHTMLTagTest >> testInitializeArgumentsMap [
 
 	self 
@@ -70,7 +70,7 @@ MicHTMLTagTest >> testParameterAtPut [
 	
 ]
 
-{ #category : #test }
+{ #category : #tests }
 MicHTMLTagTest >> testWith [
 
 	tag 

--- a/src/Microdown-HTMLExporter/MicCSSProvider.class.st
+++ b/src/Microdown-HTMLExporter/MicCSSProvider.class.st
@@ -35,10 +35,6 @@ To add a new library, add a new method to the class side category _libraries_. T
 Class {
 	#name : #MicCSSProvider,
 	#superclass : #Object,
-	#instVars : [
-		'directory',
-		'name'
-	],
 	#category : #'Microdown-HTMLExporter'
 }
 

--- a/src/Microdown-Tests/MicLinkBlockTest.class.st
+++ b/src/Microdown-Tests/MicLinkBlockTest.class.st
@@ -148,7 +148,7 @@ MicLinkBlockTest >> testPrintOn [
 	self assert: link asString equals: '[caption](http://www.pharo.org)'
 ]
 
-{ #category : #test }
+{ #category : #tests }
 MicLinkBlockTest >> testReferencePath [
 
 	link := self parseLink: self linkSample.

--- a/src/Microdown/MicAbstractBlock.class.st
+++ b/src/Microdown/MicAbstractBlock.class.st
@@ -143,24 +143,24 @@ MicAbstractBlock >> parserClass [
 	^ Microdown
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #replacement }
 MicAbstractBlock >> replace: aBlock by: anotherBlock [ 
 	
 	children replaceAll: aBlock with: anotherBlock 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #replacement }
 MicAbstractBlock >> replace: aBlock byCollection: aCollection [ 
 	
 	children := children copyReplaceAll: {aBlock} with: aCollection 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #replacement }
 MicAbstractBlock >> replaceBy: anotherBlock [ 
 	self parent replace: self by: anotherBlock
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #replacement }
 MicAbstractBlock >> replaceByAll: aCollection [ 
 	self parent replace: self byCollection: aCollection 
 ]

--- a/src/Microdown/MicAnnotationBlock.class.st
+++ b/src/Microdown/MicAnnotationBlock.class.st
@@ -93,12 +93,6 @@ MicAnnotationBlock >> openingDelimiter [
 ]
 
 { #category : #accessing }
-MicAnnotationBlock >> parameterAt: aKey put: aValue [
-	self halt: 'Is this needed???'.
-	^ arguments at: aKey put: aValue
-]
-
-{ #category : #accessing }
 MicAnnotationBlock >> printOn: aStream [
 
 	aStream nextPutAll: self openingDelimiter.

--- a/src/Microdown/MicCodeBlock.class.st
+++ b/src/Microdown/MicCodeBlock.class.st
@@ -133,15 +133,3 @@ MicCodeBlock >> size [
 
 	^ arguments at: #size
 ]
-
-{ #category : #accessing }
-MicCodeBlock >> text [
-	| text |
-	self halt: #todo.
-	"what a terrible idea we concatenate the text of children and store. 
-	I could understand that we keep the text of the parser element but then we do not modify it after
-	and certainly not change it."
-	text := ''.
-	body do: [ :each | text := text , each text ].
-	^ text
-]

--- a/src/Microdown/MicSameStartStopMarkupBlock.class.st
+++ b/src/Microdown/MicSameStartStopMarkupBlock.class.st
@@ -27,12 +27,6 @@ MicSameStartStopMarkupBlock >> arguments [
 	^ arguments
 ]
 
-{ #category : #accessing }
-MicSameStartStopMarkupBlock >> arguments: aDictionary [
-	self halt: 'Do not set this'.
-	arguments := aDictionary
-]
-
 { #category : #visiting }
 MicSameStartStopMarkupBlock >> caption [
 	^ String streamContents: [:s |  self captionElements do: [ :each | s nextPutAll: each substring ] ]


### PR DESCRIPTION
There are some of the problems which are not in the microdown project, but in its dependencies.
- testNoLeadingOrTrailingSpacesInCategoryNames - is caused by 
  `DTDEntity->#'private ' XMLEnumerationAttributeValidator->#'private ' BaselineOfXMLParser->#'prerequisites ' XMLHTTPZincRequest->#'private ' XMLHTTPDecompressingReadStreamAdapterFactory class->#'private ' SAX2Parser class->#'private '`
- testNoUncategorizedMethods - microdown parts fixed in 3255d96b87ccf1e3a5fb47d1e7a1bb0113044adf, but the following remains: `PRFigure PRMetadata PRParameters class StDebuggerCommand`
- testMethodsContainNoHalt fixed. There was a number of obsolete methods which contained a halt to alert if called. Now they are deleted.
- testObsoleteClasses  - when running in local image, I get: AnObsoleteMicArgumentList, the CI integration test mentions `AnObsoleteMicroSharedPool AnObsoleteMicElement AnObsoleteMicInlineElement AnObsoleteMicAnnotationBlock AnObsoleteMicTextStyler`. In my experience this error can be hard.
- testProperTestProtocolIsUsed - renamed some protocols to `tests` rather than `test`.