### PR TITLE
Fixes #411 tailoring richtext composer using microdown

### DIFF
--- a/src/Microdown-RichTextComposer-Tests/MicCodeStylerSpecTest.class.st
+++ b/src/Microdown-RichTextComposer-Tests/MicCodeStylerSpecTest.class.st
@@ -18,8 +18,7 @@ MicCodeStylerSpecTest >> setUp [
 MicCodeStylerSpecTest >> testStylerForMethod [
 	
 	| code richText blueLocation textColor |
-	code := '
-codeStylerFor: aString
+	code := 'codeStylerFor: aString
 <codeblockStylerFor: #smalltalk>
 
 ^bobby new 

--- a/src/Microdown-RichTextComposer-Tests/MicDynamicTextStylerTest.class.st
+++ b/src/Microdown-RichTextComposer-Tests/MicDynamicTextStylerTest.class.st
@@ -8,6 +8,16 @@ Class {
 }
 
 { #category : #tests }
+MicDynamicTextStylerTest >> testBodyFont [
+	| styler |
+	styler := MicDynamicTextStyler new.
+	self assert: styler bodyFont equals: TextStyle defaultFont.
+	styler bodyFont: 'Source Sans Pro;72'.
+	self assert: styler bodyFont familyName equals: 'Source Sans Pro'.
+	self assert: styler bodyFont pointSize equals: 72.
+]
+
+{ #category : #tests }
 MicDynamicTextStylerTest >> testBulletForLevel [
 	| styler |
 	styler := MicDynamicTextStyler new.
@@ -15,6 +25,11 @@ MicDynamicTextStylerTest >> testBulletForLevel [
 	self assert: (styler bulletForLevel: 0) equals: 'a' asText.
 	self assert: (styler bulletForLevel: 2) equals: 'c' asText.
 	self assert: (styler bulletForLevel: 3) equals: 'a' asText.
+]
+
+{ #category : #tests }
+MicDynamicTextStylerTest >> testBullets [
+	"I am not needed as I am tested by testCounterForAtLevel, but being here marks counters: as tested"
 ]
 
 { #category : #tests }
@@ -31,6 +46,11 @@ MicDynamicTextStylerTest >> testCounterForAtLevel [
 	self assert: (styler counterFor: 2 atLevel: 2) equals: 'b)' asText.
 	self assert: (styler counterFor: 3 atLevel: 3) equals: '3.' asText.
 	self assert: (styler counterFor: 5 atLevel: 5) equals: 'e)' asText.
+]
+
+{ #category : #tests }
+MicDynamicTextStylerTest >> testCounters [
+	"I am not needed as I am tested by testCounterForAtLevel, but being here marks counters: as tested"
 ]
 
 { #category : #tests }
@@ -93,5 +113,16 @@ MicDynamicTextStylerTest >> testNewLineIfNotAlready [
 	self assert: styler newLineIfNotAlready equals: String tab asText.
 	styler newLineIfNotAlready: 'cr;tab;space'.
 	self assert: styler newLineIfNotAlready equals: (String cr, String tab, String space) asText
+	
+]
+
+{ #category : #tests }
+MicDynamicTextStylerTest >> testSpaceAfterHeader [
+	| styler |
+	styler := MicDynamicTextStyler new.
+	self assert: styler spaceAfterHeader equals: #(1 1 1 1 1 1).
+	styler spaceAfterHeader: '2;2'.
+	self assert: styler spaceAfterHeader equals: #(2 2 1 1 1 1).
+	
 	
 ]

--- a/src/Microdown-RichTextComposer-Tests/MicDynamicTextStylerTest.class.st
+++ b/src/Microdown-RichTextComposer-Tests/MicDynamicTextStylerTest.class.st
@@ -1,0 +1,57 @@
+"
+A MicDynamicTextStylerTest is a test class for testing the behavior of MicDynamicTextStyler
+"
+Class {
+	#name : #MicDynamicTextStylerTest,
+	#superclass : #TestCase,
+	#category : #'Microdown-RichTextComposer-Tests-Composer'
+}
+
+{ #category : #tests }
+MicDynamicTextStylerTest >> testBulletForLevel [
+	| styler |
+	styler := MicDynamicTextStyler new.
+	styler bullets: 'abc'.
+	self assert: (styler bulletForLevel: 0) equals: 'a' asText.
+	self assert: (styler bulletForLevel: 2) equals: 'c' asText.
+	self assert: (styler bulletForLevel: 3) equals: 'a' asText.
+]
+
+{ #category : #tests }
+MicDynamicTextStylerTest >> testCounterForAtLevel [
+	| styler |
+	styler := MicDynamicTextStyler new.
+	styler counters: 'Aa1'.
+	self assert: (styler counterFor: 1 atLevel: 1) equals: 'A)' asText.
+	self assert: (styler counterFor: 2 atLevel: 2) equals: 'b)' asText.
+	self assert: (styler counterFor: 3 atLevel: 3) equals: '3.' asText.
+	self assert: (styler counterFor: 5 atLevel: 5) equals: 'e)' asText.
+]
+
+{ #category : #tests }
+MicDynamicTextStylerTest >> testHeaderFontForLevel [
+	| styler |
+	styler := MicDynamicTextStyler new.
+	styler headerFont: 'Source Sans Pro;72' forLevel: 1.
+	self assert: (styler headerLevelFont: 1) familyName equals: 'Source Sans Pro'.
+	self assert: (styler headerLevelFont: 1) pointSize equals: 72.
+]
+
+{ #category : #tests }
+MicDynamicTextStylerTest >> testHeaderFontForLevel_wrongFormat [
+	| styler |
+	styler := MicDynamicTextStyler new.
+	self 
+		should: [ styler headerFont: 'Source Sans Pro' forLevel: 1 ]
+	 	raise: MicParsingError .
+	
+]
+
+{ #category : #tests }
+MicDynamicTextStylerTest >> testHeaderFontForLevel_wrongLevel [
+	| styler |
+	styler := MicDynamicTextStyler new.
+	self 
+		should: [styler headerFont: 'Source Sans Pro;72' forLevel: 9]
+		raise: MicParsingError
+]

--- a/src/Microdown-RichTextComposer-Tests/MicDynamicTextStylerTest.class.st
+++ b/src/Microdown-RichTextComposer-Tests/MicDynamicTextStylerTest.class.st
@@ -104,6 +104,17 @@ MicDynamicTextStylerTest >> testInterblockSpacing [
 ]
 
 { #category : #tests }
+MicDynamicTextStylerTest >> testKeepCRFromInput [
+	| styler textSample|
+	styler := MicDynamicTextStyler new.
+	textSample := 'aaa\bbb' withCRs asText.
+	self assert: (styler postTextTreatment: textSample copy) equals: textSample.
+	styler keepCRFromInput: 'false'.
+	self assert: (styler postTextTreatment: textSample copy) equals: 'aaa bbb' asText.
+	
+]
+
+{ #category : #tests }
 MicDynamicTextStylerTest >> testMonospaceBackgroundColor [
 	| styler |
 	styler := MicDynamicTextStyler new.

--- a/src/Microdown-RichTextComposer-Tests/MicDynamicTextStylerTest.class.st
+++ b/src/Microdown-RichTextComposer-Tests/MicDynamicTextStylerTest.class.st
@@ -22,9 +22,9 @@ MicDynamicTextStylerTest >> testBulletForLevel [
 	| styler |
 	styler := MicDynamicTextStyler new.
 	styler bullets: 'abc'.
-	self assert: (styler bulletForLevel: 0) equals: 'a' asText.
-	self assert: (styler bulletForLevel: 2) equals: 'c' asText.
-	self assert: (styler bulletForLevel: 3) equals: 'a' asText.
+	self assert: (styler bulletForLevel: 1) equals: 'a' asText.
+	self assert: (styler bulletForLevel: 2) equals: 'b' asText.
+	self assert: (styler bulletForLevel: 4) equals: 'a' asText.
 ]
 
 { #category : #tests }
@@ -54,12 +54,23 @@ MicDynamicTextStylerTest >> testCounters [
 ]
 
 { #category : #tests }
+MicDynamicTextStylerTest >> testCrAfterHeader [
+	| styler |
+	styler := MicDynamicTextStyler new.
+	self assert: styler crAfterHeaders equals: #(1 1 1 1 1 1).
+	styler crAfterHeader: '2;2'.
+	self assert: styler crAfterHeaders equals: #(2 2 1 1 1 1).
+	
+	
+]
+
+{ #category : #tests }
 MicDynamicTextStylerTest >> testHeaderFontForLevel [
 	| styler |
 	styler := MicDynamicTextStyler new.
 	styler headerFont: 'Source Sans Pro;72' forLevel: 1.
-	self assert: (styler headerLevelFont: 1) familyName equals: 'Source Sans Pro'.
-	self assert: (styler headerLevelFont: 1) pointSize equals: 72.
+	self assert: (styler headerLevelFont: 1) font familyName equals: 'Source Sans Pro'.
+	self assert: (styler headerLevelFont: 1) font pointSize equals: 72.
 ]
 
 { #category : #tests }
@@ -85,11 +96,11 @@ MicDynamicTextStylerTest >> testHeaderFontForLevel_wrongLevel [
 MicDynamicTextStylerTest >> testInterblockSpacing [
 	| styler |
 	styler := MicDynamicTextStyler new.
-	self assert: styler interblockSpacing equals: String cr asText.
-	styler interblockSpacing: '0'.
-	self assert: styler interblockSpacing equals: '' asText.
-	styler interblockSpacing: '2'.
-	self assert: styler interblockSpacing equals: (String cr, String cr) asText
+	self assert: styler interBlockSpacing equals: String cr asText.
+	styler interBlockSpacing: '0'.
+	self assert: styler interBlockSpacing equals: '' asText.
+	styler interBlockSpacing: '2'.
+	self assert: styler interBlockSpacing equals: (String cr, String cr) asText
 ]
 
 { #category : #tests }
@@ -113,16 +124,5 @@ MicDynamicTextStylerTest >> testNewLineIfNotAlready [
 	self assert: styler newLineIfNotAlready equals: String tab asText.
 	styler newLineIfNotAlready: 'cr;tab;space'.
 	self assert: styler newLineIfNotAlready equals: (String cr, String tab, String space) asText
-	
-]
-
-{ #category : #tests }
-MicDynamicTextStylerTest >> testSpaceAfterHeader [
-	| styler |
-	styler := MicDynamicTextStyler new.
-	self assert: styler spaceAfterHeader equals: #(1 1 1 1 1 1).
-	styler spaceAfterHeader: '2;2'.
-	self assert: styler spaceAfterHeader equals: #(2 2 1 1 1 1).
-	
 	
 ]

--- a/src/Microdown-RichTextComposer-Tests/MicDynamicTextStylerTest.class.st
+++ b/src/Microdown-RichTextComposer-Tests/MicDynamicTextStylerTest.class.st
@@ -18,6 +18,11 @@ MicDynamicTextStylerTest >> testBulletForLevel [
 ]
 
 { #category : #tests }
+MicDynamicTextStylerTest >> testCodeBackgroundColor [
+	
+]
+
+{ #category : #tests }
 MicDynamicTextStylerTest >> testCounterForAtLevel [
 	| styler |
 	styler := MicDynamicTextStyler new.
@@ -54,4 +59,39 @@ MicDynamicTextStylerTest >> testHeaderFontForLevel_wrongLevel [
 	self 
 		should: [styler headerFont: 'Source Sans Pro;72' forLevel: 9]
 		raise: MicParsingError
+]
+
+{ #category : #tests }
+MicDynamicTextStylerTest >> testInterblockSpacing [
+	| styler |
+	styler := MicDynamicTextStyler new.
+	self assert: styler interblockSpacing equals: String cr asText.
+	styler interblockSpacing: '0'.
+	self assert: styler interblockSpacing equals: '' asText.
+	styler interblockSpacing: '2'.
+	self assert: styler interblockSpacing equals: (String cr, String cr) asText
+]
+
+{ #category : #tests }
+MicDynamicTextStylerTest >> testMonospaceBackgroundColor [
+	| styler |
+	styler := MicDynamicTextStyler new.
+	self assert: styler monospaceBackgroundColor equals: Smalltalk ui theme settings windowColor.
+	styler monospaceBackgroundColor: 'red'.
+	self assert: styler monospaceBackgroundColor equals: Color red.
+	styler monospaceBackgroundColor: '#FF0000'.
+	self assert: styler monospaceBackgroundColor equals: Color red
+	
+]
+
+{ #category : #tests }
+MicDynamicTextStylerTest >> testNewLineIfNotAlready [
+	| styler |
+	styler := MicDynamicTextStyler new.
+	self assert: styler newLineIfNotAlready equals: String cr asText.
+	styler newLineIfNotAlready: 'tab'.
+	self assert: styler newLineIfNotAlready equals: String tab asText.
+	styler newLineIfNotAlready: 'cr;tab;space'.
+	self assert: styler newLineIfNotAlready equals: (String cr, String tab, String space) asText
+	
 ]

--- a/src/Microdown-RichTextComposer-Tests/MicRichTextComposerTest.class.st
+++ b/src/Microdown-RichTextComposer-Tests/MicRichTextComposerTest.class.st
@@ -209,11 +209,9 @@ line 2
 	runs := (richText runs collect: [:run | run collect: [:a| a class]]) asArray .	
 		 
 	self assert: (runs second includes: TextIndent).
-	self assert: richText asString equals: 
+	self assert: richText asString trim equals: 
 'line 1
-line 2
-
-'
+line 2'
 ]
 
 { #category : #'tests - codeBlock' }
@@ -262,12 +260,10 @@ line 2
 	self assert: runs first notEmpty. 
 	self assert: (runs second anySatisfy: [ :r | r class = TextIndent]).
 	self assert: ((runs at: 15) includes: self boldFormat ).
-	self assert: richText asString equals: 
+	self assert: richText asString trim equals: 
 'line 1
 line 2
-Roger Rabbit
-
-'
+Roger Rabbit'
 ]
 
 { #category : #'skipped tests' }
@@ -504,9 +500,7 @@ MicRichTextComposerTest >> testNoNSuperfluousNewLines [
 And this is just an other paragraph'.
 	expected := 'This is bold
 
-And this is just an other paragraph
-
-'.
+And this is just an other paragraph'.
 	richText := self richTextForString: source.
 	self assert: richText asString equals: expected
 ]
@@ -516,9 +510,7 @@ MicRichTextComposerTest >> testNosuperfluousNewLines [
 
 	| source richText expected |
 	source :=  'This is **bold**'.
-	expected := 'This is bold
-
-'.
+	expected := 'This is bold'.
 	richText := self richTextForString: source.
 	self assert: richText asString equals: expected
 ]

--- a/src/Microdown-RichTextComposer-Tests/MicRichTextComposerTest.class.st
+++ b/src/Microdown-RichTextComposer-Tests/MicRichTextComposerTest.class.st
@@ -472,7 +472,7 @@ MicRichTextComposerTest >> testNestedMixedListNoEmptyLinesEfterSubLists [
 { #category : #'skipped tests' }
 MicRichTextComposerTest >> testNestedUnorderdList [
 
-	| source richText runs |
+	| source richText |
 	source := 
 '- item 1
   - sub item 1.1
@@ -481,11 +481,9 @@ MicRichTextComposerTest >> testNestedUnorderdList [
   - sub item 2.2
 - item 3'.
 	richText := self richTextForString: source.
-	runs := richText runs.
-	
 	"check that 'sub item 1.1' is bulleted and is rightly indented"
-	self assert: (richText asString at: 10) equals: $•.
-	self assert: (runs at: 12) first amount equals: 4
+	self assert: (richText asString includesSubstring: '•	item 2').
+	self assert: (richText asString includesSubstring: '-	sub item 2.1')
 	
 ]
 
@@ -540,6 +538,20 @@ MicRichTextComposerTest >> testOrderedList [
 	self assert: runs first first amount equals: 1.
 	self assert: (runs at: 30) "the first o in 'on two lines'" first class equals: TextIndent.
 	self assert: (runs at: 30) first amount equals: 2.
+	
+]
+
+{ #category : #tests }
+MicRichTextComposerTest >> testOrderedNestedList [
+	| source richText   |
+	source := '
+1. First item
+   2. Second item
+      3. Third item'.
+	richText := self richTextForString: source.
+	self assert: (richText asString includesSubstring: '1.	First item').
+	self assert: (richText asString includesSubstring: 'A)	Second item').
+	self assert: (richText asString includesSubstring: 'a)	Third item')
 	
 ]
 

--- a/src/Microdown-RichTextComposer-Tests/MicRichTextFormatConfigurationTest.class.st
+++ b/src/Microdown-RichTextComposer-Tests/MicRichTextFormatConfigurationTest.class.st
@@ -7,14 +7,19 @@ Class {
 	#category : #'Microdown-RichTextComposer-Tests-Composer'
 }
 
+{ #category : #'as yet unclassified' }
+MicRichTextFormatConfigurationTest >> fontString [
+	^ TextStyle defaultFont familyName,';72'
+]
+
 { #category : #tests }
 MicRichTextFormatConfigurationTest >> testBodyFont [
 	| richText |
 	richText := Microdown asRichText: '
 foo bar'.
 	self assert: (richText asMorph height < 50).
-	richText := Microdown asRichText: '{!richtext|bodyFont=Lucida Grande;72!}
-foo bar'.
+	richText := Microdown asRichText: ('{!richtext|bodyFont=$font$!}
+foo bar' copyReplaceAll: '$font$' with: self fontString).
 	self assert: (richText asMorph height > 100).
 
 ]
@@ -64,8 +69,9 @@ MicRichTextFormatConfigurationTest >> testCounters [
 { #category : #tests }
 MicRichTextFormatConfigurationTest >> testHeader1 [
 	| src richText |
-	src := '{!richtext|headerFont1=Lucida Grande;72!}
+	src := '{!richtext|headerFont1=$font$!}
 # Huge header'.
+	src := src copyReplaceAll: '$font$' with: self fontString. 
 	richText := Microdown asRichText: src.
 	self assert: (richText asMorph height > 100).
 ]
@@ -73,8 +79,9 @@ MicRichTextFormatConfigurationTest >> testHeader1 [
 { #category : #tests }
 MicRichTextFormatConfigurationTest >> testHeader2 [
 	| src richText |
-	src := '{!richtext|headerFont2=Lucida Grande;72!}
+	src := '{!richtext|headerFont2=$font$!}
 ## Huge header'.
+	src := src copyReplaceAll: '$font$' with: self fontString. 
 	richText := Microdown asRichText: src.
 	self assert: (richText asMorph height > 100).
 ]
@@ -82,8 +89,9 @@ MicRichTextFormatConfigurationTest >> testHeader2 [
 { #category : #tests }
 MicRichTextFormatConfigurationTest >> testHeader3 [
 	| src richText |
-	src := '{!richtext|headerFont3=Lucida Grande;72!}
+	src := '{!richtext|headerFont3=$font$!}
 ### Huge header'.
+	src := src copyReplaceAll: '$font$' with: self fontString. 
 	richText := Microdown asRichText: src.
 	self assert: (richText asMorph height > 100).
 ]
@@ -91,8 +99,9 @@ MicRichTextFormatConfigurationTest >> testHeader3 [
 { #category : #tests }
 MicRichTextFormatConfigurationTest >> testHeader4 [
 	| src richText |
-	src := '{!richtext|headerFont4=Lucida Grande;72!}
+	src := '{!richtext|headerFont4=$font$!}
 #### Huge header'.
+	src := src copyReplaceAll: '$font$' with: self fontString. 
 	richText := Microdown asRichText: src.
 	self assert: (richText asMorph height > 100).
 ]
@@ -100,8 +109,9 @@ MicRichTextFormatConfigurationTest >> testHeader4 [
 { #category : #tests }
 MicRichTextFormatConfigurationTest >> testHeader5 [
 	| src richText |
-	src := '{!richtext|headerFont5=Lucida Grande;72!}
+	src := '{!richtext|headerFont5=$font$!}
 ##### Huge header'.
+	src := src copyReplaceAll: '$font$' with: self fontString. 
 	richText := Microdown asRichText: src.
 	self assert: (richText asMorph height > 100).
 ]
@@ -109,8 +119,9 @@ MicRichTextFormatConfigurationTest >> testHeader5 [
 { #category : #tests }
 MicRichTextFormatConfigurationTest >> testHeader6 [
 	| src richText |
-	src := '{!richtext|headerFont6=Lucida Grande;72!}
+	src := '{!richtext|headerFont6=$font$!}
 ###### Huge header'.
+	src := src copyReplaceAll: '$font$' with: self fontString. 
 	richText := Microdown asRichText: src.
 	self assert: (richText asMorph height > 100).
 ]

--- a/src/Microdown-RichTextComposer-Tests/MicRichTextFormatConfigurationTest.class.st
+++ b/src/Microdown-RichTextComposer-Tests/MicRichTextFormatConfigurationTest.class.st
@@ -1,0 +1,168 @@
+"
+A MicRichTextFormatConfigurationTest is a test class for testing the behavior of MicRichTextFormatConfiguration
+"
+Class {
+	#name : #MicRichTextFormatConfigurationTest,
+	#superclass : #TestCase,
+	#category : #'Microdown-RichTextComposer-Tests-Composer'
+}
+
+{ #category : #tests }
+MicRichTextFormatConfigurationTest >> testBodyFont [
+	| richText |
+	richText := Microdown asRichText: '
+
+foo bar'.
+	self assert: (richText asMorph height < 50).
+	richText := Microdown asRichText: '{!richtext|bodyFont=Lucida Grande;72!}
+
+foo bar'.
+	self assert: (richText asMorph height < 50).
+
+]
+
+{ #category : #tests }
+MicRichTextFormatConfigurationTest >> testBullets [
+	| src richText |
+	src := '{!richtext|bullets=◊»!}
+- aaa
+  - bbb'.
+	richText := Microdown asRichText: src.
+	self assert: (richText asString includesSubstring: '◊	aaa').
+	self assert: (richText asString includesSubstring: '»	bbb')
+]
+
+{ #category : #tests }
+MicRichTextFormatConfigurationTest >> testCounters [
+	| src richText |
+	src := '{!richtext|counters=A1!}
+1. aaa
+   9. bbb'.
+	richText := Microdown asRichText: src.
+	self assert: (richText asString includesSubstring: 'A)	aaa').
+	self assert: (richText asString includesSubstring: '1.	bbb')
+]
+
+{ #category : #tests }
+MicRichTextFormatConfigurationTest >> testHeader1 [
+	| src richText |
+	src := '{!richtext|headerFont1=Lucida Grande;72!}
+# Huge header'.
+	richText := Microdown asRichText: src.
+	self assert: (richText asMorph height > 150).
+]
+
+{ #category : #tests }
+MicRichTextFormatConfigurationTest >> testHeader2 [
+	| src richText |
+	src := '{!richtext|headerFont2=Lucida Grande;72!}
+## Huge header'.
+	richText := Microdown asRichText: src.
+	self assert: (richText asMorph height > 150).
+]
+
+{ #category : #tests }
+MicRichTextFormatConfigurationTest >> testHeader3 [
+	| src richText |
+	src := '{!richtext|headerFont3=Lucida Grande;72!}
+### Huge header'.
+	richText := Microdown asRichText: src.
+	self assert: (richText asMorph height > 150).
+]
+
+{ #category : #tests }
+MicRichTextFormatConfigurationTest >> testHeader4 [
+	| src richText |
+	src := '{!richtext|headerFont4=Lucida Grande;72!}
+#### Huge header'.
+	richText := Microdown asRichText: src.
+	self assert: (richText asMorph height > 150).
+]
+
+{ #category : #tests }
+MicRichTextFormatConfigurationTest >> testHeader5 [
+	| src richText |
+	src := '{!richtext|headerFont5=Lucida Grande;72!}
+##### Huge header'.
+	richText := Microdown asRichText: src.
+	self assert: (richText asMorph height > 150).
+]
+
+{ #category : #tests }
+MicRichTextFormatConfigurationTest >> testHeader6 [
+	| src richText |
+	src := '{!richtext|headerFont6=Lucida Grande;72!}
+###### Huge header'.
+	richText := Microdown asRichText: src.
+	self assert: (richText asMorph height > 150).
+]
+
+{ #category : #tests }
+MicRichTextFormatConfigurationTest >> testIllegalArgument [
+	| src richText |
+	src := '{!richtext|foo=bar!}'.
+	self should: [ 	richText := Microdown asRichText: src]
+		raise: MicParsingError 
+]
+
+{ #category : #tests }
+MicRichTextFormatConfigurationTest >> testInterBlockSpacing [ 
+	| src richText |
+	src := '{!richtext|interBlockSpacing=0!}fooo
+
+bar
+
+boo'.
+	richText := Microdown asRichText: src.
+	self assert: (richText asString lines size) equals: 3
+]
+
+{ #category : #tests }
+MicRichTextFormatConfigurationTest >> testInterBlockSpacing_three [
+	| src richText |
+	src := '{!richtext|interBlockSpacing=3!}fooo
+
+bar
+
+boo'.
+	richText := Microdown asRichText: src.
+	self assert: (richText asString lines size) equals: 9
+]
+
+{ #category : #tests }
+MicRichTextFormatConfigurationTest >> testNewLineIfNotAlready [
+	| src richText |
+	"newLineIfNotAlready mostely makes sense if interBlockSpacing is 0"
+	src := '{!richtext|newLineIfNotAlready=cr;tab&interBlockSpacing=0!}
+foo
+
+bar'.
+	richText := Microdown asRichText: src.
+	self assert: (richText asString) equals: '
+foo
+	bar'
+]
+
+{ #category : #tests }
+MicRichTextFormatConfigurationTest >> testSpaceAfterHeader [
+	| src richText |
+	"newLineIfNotAlready mostely makes sense if interBlockSpacing is 0"
+	src := '{!richtext|crAfterHeader=2;2;1;1!}
+# Header 1
+## Header 2
+### Header 3
+#### Header 4
+##### Header 5
+###### Header 6'.
+	richText := Microdown asRichText: src.
+	self assert: (richText asString) equals: '
+Header 1
+
+Header 2
+
+Header 3
+Header 4
+Header 5
+Header 6
+'
+]

--- a/src/Microdown-RichTextComposer-Tests/MicRichTextFormatConfigurationTest.class.st
+++ b/src/Microdown-RichTextComposer-Tests/MicRichTextFormatConfigurationTest.class.st
@@ -11,13 +11,11 @@ Class {
 MicRichTextFormatConfigurationTest >> testBodyFont [
 	| richText |
 	richText := Microdown asRichText: '
-
 foo bar'.
 	self assert: (richText asMorph height < 50).
 	richText := Microdown asRichText: '{!richtext|bodyFont=Lucida Grande;72!}
-
 foo bar'.
-	self assert: (richText asMorph height < 50).
+	self assert: (richText asMorph height > 100).
 
 ]
 
@@ -30,6 +28,26 @@ MicRichTextFormatConfigurationTest >> testBullets [
 	richText := Microdown asRichText: src.
 	self assert: (richText asString includesSubstring: '◊	aaa').
 	self assert: (richText asString includesSubstring: '»	bbb')
+]
+
+{ #category : #tests }
+MicRichTextFormatConfigurationTest >> testChangingSameStyler [
+	| src richText |
+	"Test that the same styler is changed"
+	src := '{!richtext|crAfterHeader=3!}
+# Header 1
+{!richtext|crAfterHeader=1!}
+# Header 2
+last line
+'.
+	richText := Microdown asRichText: src.
+	self assert: (richText asString) equals: 
+'Header 1
+
+
+
+Header 2
+last line'
 ]
 
 { #category : #tests }
@@ -49,7 +67,7 @@ MicRichTextFormatConfigurationTest >> testHeader1 [
 	src := '{!richtext|headerFont1=Lucida Grande;72!}
 # Huge header'.
 	richText := Microdown asRichText: src.
-	self assert: (richText asMorph height > 150).
+	self assert: (richText asMorph height > 100).
 ]
 
 { #category : #tests }
@@ -58,7 +76,7 @@ MicRichTextFormatConfigurationTest >> testHeader2 [
 	src := '{!richtext|headerFont2=Lucida Grande;72!}
 ## Huge header'.
 	richText := Microdown asRichText: src.
-	self assert: (richText asMorph height > 150).
+	self assert: (richText asMorph height > 100).
 ]
 
 { #category : #tests }
@@ -67,7 +85,7 @@ MicRichTextFormatConfigurationTest >> testHeader3 [
 	src := '{!richtext|headerFont3=Lucida Grande;72!}
 ### Huge header'.
 	richText := Microdown asRichText: src.
-	self assert: (richText asMorph height > 150).
+	self assert: (richText asMorph height > 100).
 ]
 
 { #category : #tests }
@@ -76,7 +94,7 @@ MicRichTextFormatConfigurationTest >> testHeader4 [
 	src := '{!richtext|headerFont4=Lucida Grande;72!}
 #### Huge header'.
 	richText := Microdown asRichText: src.
-	self assert: (richText asMorph height > 150).
+	self assert: (richText asMorph height > 100).
 ]
 
 { #category : #tests }
@@ -85,7 +103,7 @@ MicRichTextFormatConfigurationTest >> testHeader5 [
 	src := '{!richtext|headerFont5=Lucida Grande;72!}
 ##### Huge header'.
 	richText := Microdown asRichText: src.
-	self assert: (richText asMorph height > 150).
+	self assert: (richText asMorph height > 100).
 ]
 
 { #category : #tests }
@@ -94,7 +112,7 @@ MicRichTextFormatConfigurationTest >> testHeader6 [
 	src := '{!richtext|headerFont6=Lucida Grande;72!}
 ###### Huge header'.
 	richText := Microdown asRichText: src.
-	self assert: (richText asMorph height > 150).
+	self assert: (richText asMorph height > 100).
 ]
 
 { #category : #tests }
@@ -126,7 +144,7 @@ bar
 
 boo'.
 	richText := Microdown asRichText: src.
-	self assert: (richText asString lines size) equals: 9
+	self assert: (richText asString lines size) equals: 7
 ]
 
 { #category : #tests }
@@ -138,15 +156,14 @@ foo
 
 bar'.
 	richText := Microdown asRichText: src.
-	self assert: (richText asString) equals: '
-foo
+	self assert: (richText asString) equals: 
+'foo
 	bar'
 ]
 
 { #category : #tests }
 MicRichTextFormatConfigurationTest >> testSpaceAfterHeader [
 	| src richText |
-	"newLineIfNotAlready mostely makes sense if interBlockSpacing is 0"
 	src := '{!richtext|crAfterHeader=2;2;1;1!}
 # Header 1
 ## Header 2
@@ -155,14 +172,13 @@ MicRichTextFormatConfigurationTest >> testSpaceAfterHeader [
 ##### Header 5
 ###### Header 6'.
 	richText := Microdown asRichText: src.
-	self assert: (richText asString) equals: '
-Header 1
+	self assert: (richText asString) equals: 
+'Header 1
 
 Header 2
 
 Header 3
 Header 4
 Header 5
-Header 6
-'
+Header 6'
 ]

--- a/src/Microdown-RichTextComposer/MicCodeStylerSpec.class.st
+++ b/src/Microdown-RichTextComposer/MicCodeStylerSpec.class.st
@@ -36,11 +36,18 @@ MicCodeStylerSpec class >> buildCache [
 ]
 
 { #category : #stylers }
-MicCodeStylerSpec class >> codeStylerForMethod: aString [
+MicCodeStylerSpec class >> codeStylerForMethod: sourceString [
 	<codeblockStyler: 'Method'>
-	^MicSmalltalkTextStyler new 
-		isForWorkspace: false; 
-		styledTextFor: aString asText
+	| source styler ast|
+	source := sourceString asText.
+	styler := MicSmalltalkTextStyler new.
+	ast := self class compiler
+		source: source asString;
+		parse.				
+	styler style: source ast: ast.
+	^ source 
+	
+	
 ]
 
 { #category : #stylers }

--- a/src/Microdown-RichTextComposer/MicDynamicTextStyler.class.st
+++ b/src/Microdown-RichTextComposer/MicDynamicTextStyler.class.st
@@ -25,6 +25,7 @@ Bullets can be tailored: `{!richtext|bullets=xo!}` {!richtext|bullets=xo!}:
 
 
 Font sizes can be changed `{!richtext|headerFont3=Source Sans Pro;10&bodyFont=Source Sans Pro;7!}`
+
 {!richtext|headerFont3=Source Sans Pro;10&bodyFont=Source Sans Pro;7!}
 ### Tiny header
 and very small body

--- a/src/Microdown-RichTextComposer/MicDynamicTextStyler.class.st
+++ b/src/Microdown-RichTextComposer/MicDynamicTextStyler.class.st
@@ -144,6 +144,7 @@ MicDynamicTextStyler >> initialize [
 	newLineIfNotAlready := String cr asText.
 	bodyFont := TextStyle defaultFont.
 	crAfterHeader := #(1 1 1 1 1 1).
+	keepCRFromInput := true.
 ]
 
 { #category : #'composer styles' }
@@ -155,6 +156,12 @@ MicDynamicTextStyler >> interBlockSpacing [
 MicDynamicTextStyler >> interBlockSpacing: spacingSpec [
 	"I can put a number of cr between blocks. "
 	interBlockSpacing := ((String cr) repeat: (spacingSpec asNumber)) asText
+]
+
+{ #category : #accessing }
+MicDynamicTextStyler >> keepCRFromInput: aBooleanText [
+	"if aBooleanText is 'false', set keepCRFromInput to false. This will merge lines in text blocks to a single line"
+	keepCRFromInput := aBooleanText ~= 'false'
 ]
 
 { #category : #'composer styles' }
@@ -186,4 +193,15 @@ MicDynamicTextStyler >> newLineIfNotAlready: spacingSpec [
 				ifAbsent: [ MicParsingError signal: 'allowed spacings are cr|tab|space, but got: ', spec ]])
 		joinUsing: ''.
 	newLineIfNotAlready := spacing asText
+]
+
+{ #category : #'composer styles' }
+MicDynamicTextStyler >> postTextTreatment: aText [
+	"my primary purpose is to replace newLines with space in some styles"
+	keepCRFromInput ifTrue: [ ^ aText ].
+	((1 to: aText size) 
+		select: [ :i | (aText at: i) = Character cr  ]) 
+		do: [ :i | aText at: i put: Character space ].
+	^ aText
+	 
 ]

--- a/src/Microdown-RichTextComposer/MicDynamicTextStyler.class.st
+++ b/src/Microdown-RichTextComposer/MicDynamicTextStyler.class.st
@@ -15,10 +15,10 @@ Class {
 		'bullets',
 		'counters',
 		'interblockSpacing',
-		'codeBackgroundColor',
-		'newLineIfNotAkready',
 		'defaultFont',
-		'spaceAfterHeader'
+		'spaceAfterHeader',
+		'monospaceBackgroundColor',
+		'newLineIfNotAlready'
 	],
 	#category : #'Microdown-RichTextComposer-Composer'
 }
@@ -32,12 +32,6 @@ MicDynamicTextStyler >> bulletForLevel: level [
 MicDynamicTextStyler >> bullets: anObject [
 
 	bullets := anObject
-]
-
-{ #category : #accessing }
-MicDynamicTextStyler >> codeBackgroundColor: colorString [
-
-	codeBackgroundColor := Color fromString: colorString
 ]
 
 { #category : #'composer styles' }
@@ -84,28 +78,53 @@ MicDynamicTextStyler >> initialize [
 	self computeHeaderFonts. "super rely on lazy initilization"
 	bullets := '•-'.
 	counters := '1aA'.
-	interblockSpacing :=0.
-	codeBackgroundColor := Smalltalk ui theme settings windowColor.
-	newLineIfNotAkready :=0.
+	interblockSpacing := (String cr) asText.
+	monospaceBackgroundColor := Smalltalk ui theme settings windowColor.
+	newLineIfNotAlready := String cr asText.
 	defaultFont := 0.
 	spaceAfterHeader := 0.
 ]
 
 { #category : #'composer styles' }
-MicDynamicTextStyler >> interblockSpacing: anObject [
+MicDynamicTextStyler >> interblockSpacing [
+	^ interblockSpacing 
+]
 
-	interblockSpacing := anObject
+{ #category : #accessing }
+MicDynamicTextStyler >> interblockSpacing: spacingSpec [
+	"I can put a number of cr between blocks. "
+	interblockSpacing := ((String cr) repeat: (spacingSpec asNumber)) asText
 ]
 
 { #category : #'composer styles' }
 MicDynamicTextStyler >> monospaceBackgroundColor [
-	^ codeBackgroundColor 
+	^ monospaceBackgroundColor 
+]
+
+{ #category : #accessing }
+MicDynamicTextStyler >> monospaceBackgroundColor: colorString [
+
+	monospaceBackgroundColor := Color fromString: colorString
 ]
 
 { #category : #'composer styles' }
-MicDynamicTextStyler >> newLineIfNotAkready: anObject [
+MicDynamicTextStyler >> newLineIfNotAlready [ 
+	^ newLineIfNotAlready 
+]
 
-	newLineIfNotAkready := anObject
+{ #category : #'composer styles' }
+MicDynamicTextStyler >> newLineIfNotAlready: spacingSpec [
+	"add extra newline or tab indentation of the following line"
+	"spacingSpec is (cr|tab|space)* with ; as seperator - for example 'cr;tab'"
+	| commands |
+	commands := { 'cr'->String cr. 'tab'->String tab. 'space'->String space } asDictionary.
+	interblockSpacing := ((spacingSpec splitOn: ';') 
+		collect: [ :spec | 
+			commands 
+				at: spec 
+				ifAbsent: [ MicParsingError signal: 'allowed spacings are cr|tab|space, but got: ', spec ]])
+		joinUsing: ''.
+	interblockSpacing := interblockSpacing asText
 ]
 
 { #category : #'composer styles' }

--- a/src/Microdown-RichTextComposer/MicDynamicTextStyler.class.st
+++ b/src/Microdown-RichTextComposer/MicDynamicTextStyler.class.st
@@ -15,13 +15,29 @@ Class {
 		'bullets',
 		'counters',
 		'interblockSpacing',
-		'defaultFont',
 		'spaceAfterHeader',
 		'monospaceBackgroundColor',
-		'newLineIfNotAlready'
+		'newLineIfNotAlready',
+		'bodyFont'
 	],
 	#category : #'Microdown-RichTextComposer-Composer'
 }
+
+{ #category : #accessing }
+MicDynamicTextStyler >> bodyFont [
+	^ bodyFont 
+]
+
+{ #category : #accessing }
+MicDynamicTextStyler >> bodyFont: fontSpec [
+	|list|
+	list := (fontSpec splitOn: $;).
+	list size = 2 
+		ifFalse: [ MicParsingError signal: 'Font specs should be name;size - was: ',fontSpec  ].
+	bodyFont := LogicalFont 
+			familyName: list first
+			pointSize: list second asNumber
+]
 
 { #category : #initialization }
 MicDynamicTextStyler >> bulletForLevel: level [
@@ -52,12 +68,6 @@ MicDynamicTextStyler >> counters: counterTypes [
 	counters := counterTypes
 ]
 
-{ #category : #accessing }
-MicDynamicTextStyler >> defaultFont: anObject [
-
-	defaultFont := anObject
-]
-
 { #category : #'composer styles' }
 MicDynamicTextStyler >> headerFont: fontString forLevel: level [
 	|list|
@@ -81,8 +91,8 @@ MicDynamicTextStyler >> initialize [
 	interblockSpacing := (String cr) asText.
 	monospaceBackgroundColor := Smalltalk ui theme settings windowColor.
 	newLineIfNotAlready := String cr asText.
-	defaultFont := 0.
-	spaceAfterHeader := 0.
+	bodyFont := TextStyle defaultFont.
+	spaceAfterHeader := #(1 1 1 1 1 1).
 ]
 
 { #category : #'composer styles' }
@@ -116,19 +126,28 @@ MicDynamicTextStyler >> newLineIfNotAlready [
 MicDynamicTextStyler >> newLineIfNotAlready: spacingSpec [
 	"add extra newline or tab indentation of the following line"
 	"spacingSpec is (cr|tab|space)* with ; as seperator - for example 'cr;tab'"
-	| commands |
+	| commands spacing|
 	commands := { 'cr'->String cr. 'tab'->String tab. 'space'->String space } asDictionary.
-	interblockSpacing := ((spacingSpec splitOn: ';') 
+	spacing := ((spacingSpec splitOn: ';') 
 		collect: [ :spec | 
 			commands 
 				at: spec 
 				ifAbsent: [ MicParsingError signal: 'allowed spacings are cr|tab|space, but got: ', spec ]])
 		joinUsing: ''.
-	interblockSpacing := interblockSpacing asText
+	newLineIfNotAlready := spacing asText
+]
+
+{ #category : #initialization }
+MicDynamicTextStyler >> spaceAfterHeader [
+	^ spaceAfterHeader 
 ]
 
 { #category : #'composer styles' }
-MicDynamicTextStyler >> spaceAfterHeader: anObject [
-
-	spaceAfterHeader := anObject
+MicDynamicTextStyler >> spaceAfterHeader: spacingSpec [
+	"spacingSpec is a series of numbers 2;2;1;1 - which is the number of new lines to be added 
+	after headers of level1, level2 etc. 1's at the end can be omitted (2;2;1;1 is the same as 2;2)"
+	|spacings|
+	spaceAfterHeader := #(1 1 1 1 1 1) copy. "copy to get non-literal"
+	spacings := ((spacingSpec splitOn: ';') truncateTo: 6) collect: [ :spec |spec asNumber ].
+	spacings doWithIndex: [ :elem :index |spaceAfterHeader at: index put: elem ]
 ]

--- a/src/Microdown-RichTextComposer/MicDynamicTextStyler.class.st
+++ b/src/Microdown-RichTextComposer/MicDynamicTextStyler.class.st
@@ -14,11 +14,11 @@ Class {
 	#instVars : [
 		'bullets',
 		'counters',
-		'interblockSpacing',
-		'spaceAfterHeader',
 		'monospaceBackgroundColor',
 		'newLineIfNotAlready',
-		'bodyFont'
+		'bodyFont',
+		'interBlockSpacing',
+		'crAfterHeader'
 	],
 	#category : #'Microdown-RichTextComposer-Composer'
 }
@@ -41,7 +41,8 @@ MicDynamicTextStyler >> bodyFont: fontSpec [
 
 { #category : #initialization }
 MicDynamicTextStyler >> bulletForLevel: level [
-	^ ( bullets at: (level % bullets size)+1 ) asText.
+	"outer level is 1, second level is 2, "
+	^ ( bullets at: ( (level - 1) % bullets size ) +1 ) asText.
 ]
 
 { #category : #accessing }
@@ -53,6 +54,7 @@ MicDynamicTextStyler >> bullets: anObject [
 { #category : #'composer styles' }
 MicDynamicTextStyler >> counterFor: counter atLevel: level [
 	| kind |
+	"outer level is 1, second level is 2, "
 	kind := counters at: (level-1 % counters size)+1.
 	kind = $1
 		ifTrue: [ ^ counter asString asText , '.' ].
@@ -69,6 +71,26 @@ MicDynamicTextStyler >> counters: counterTypes [
 ]
 
 { #category : #'composer styles' }
+MicDynamicTextStyler >> crAfterHeader: spacingSpec [
+	"spacingSpec is a series of numbers 2;2;1;1 - which is the number of new lines to be added 
+	after headers of level1, level2 etc. 1's at the end can be omitted (2;2;1;1 is the same as 2;2)"
+	|spacings|
+	crAfterHeader := #(1 1 1 1 1 1) copy. "copy to get non-literal"
+	spacings := ((spacingSpec splitOn: ';') truncateTo: 6) collect: [ :spec |spec asNumber ].
+	spacings doWithIndex: [ :elem :index |crAfterHeader at: index put: elem ]
+]
+
+{ #category : #initialization }
+MicDynamicTextStyler >> crAfterHeaderLevel: level [
+	^ String cr repeat: (crAfterHeader at: level)
+]
+
+{ #category : #initialization }
+MicDynamicTextStyler >> crAfterHeaders [
+	^ crAfterHeader 
+]
+
+{ #category : #'composer styles' }
 MicDynamicTextStyler >> headerFont: fontString forLevel: level [
 	|list|
 	(level between: 1 and: 6) 
@@ -78,9 +100,10 @@ MicDynamicTextStyler >> headerFont: fontString forLevel: level [
 		ifFalse: [ MicParsingError signal: 'Font specs should be name;size - was: ',fontString  ].
 	headerFonts 
 		at: level 
-		put: (LogicalFont 
+		put: (TextFontReference
+				toFont:(LogicalFont 
 						familyName: list first
-						pointSize: list second asNumber)
+						pointSize: list second asNumber))
 ]
 
 { #category : #initialization }
@@ -88,22 +111,22 @@ MicDynamicTextStyler >> initialize [
 	self computeHeaderFonts. "super rely on lazy initilization"
 	bullets := '•-'.
 	counters := '1aA'.
-	interblockSpacing := (String cr) asText.
+	interBlockSpacing := (String cr) asText.
 	monospaceBackgroundColor := Smalltalk ui theme settings windowColor.
 	newLineIfNotAlready := String cr asText.
 	bodyFont := TextStyle defaultFont.
-	spaceAfterHeader := #(1 1 1 1 1 1).
+	crAfterHeader := #(1 1 1 1 1 1).
 ]
 
 { #category : #'composer styles' }
-MicDynamicTextStyler >> interblockSpacing [
-	^ interblockSpacing 
+MicDynamicTextStyler >> interBlockSpacing [
+	^ interBlockSpacing 
 ]
 
 { #category : #accessing }
-MicDynamicTextStyler >> interblockSpacing: spacingSpec [
+MicDynamicTextStyler >> interBlockSpacing: spacingSpec [
 	"I can put a number of cr between blocks. "
-	interblockSpacing := ((String cr) repeat: (spacingSpec asNumber)) asText
+	interBlockSpacing := ((String cr) repeat: (spacingSpec asNumber)) asText
 ]
 
 { #category : #'composer styles' }
@@ -127,7 +150,7 @@ MicDynamicTextStyler >> newLineIfNotAlready: spacingSpec [
 	"add extra newline or tab indentation of the following line"
 	"spacingSpec is (cr|tab|space)* with ; as seperator - for example 'cr;tab'"
 	| commands spacing|
-	commands := { 'cr'->String cr. 'tab'->String tab. 'space'->String space } asDictionary.
+	commands := { ''-> ''. 'cr'->String cr. 'tab'->String tab. 'space'->String space } asDictionary.
 	spacing := ((spacingSpec splitOn: ';') 
 		collect: [ :spec | 
 			commands 
@@ -135,19 +158,4 @@ MicDynamicTextStyler >> newLineIfNotAlready: spacingSpec [
 				ifAbsent: [ MicParsingError signal: 'allowed spacings are cr|tab|space, but got: ', spec ]])
 		joinUsing: ''.
 	newLineIfNotAlready := spacing asText
-]
-
-{ #category : #initialization }
-MicDynamicTextStyler >> spaceAfterHeader [
-	^ spaceAfterHeader 
-]
-
-{ #category : #'composer styles' }
-MicDynamicTextStyler >> spaceAfterHeader: spacingSpec [
-	"spacingSpec is a series of numbers 2;2;1;1 - which is the number of new lines to be added 
-	after headers of level1, level2 etc. 1's at the end can be omitted (2;2;1;1 is the same as 2;2)"
-	|spacings|
-	spaceAfterHeader := #(1 1 1 1 1 1) copy. "copy to get non-literal"
-	spacings := ((spacingSpec splitOn: ';') truncateTo: 6) collect: [ :spec |spec asNumber ].
-	spacings doWithIndex: [ :elem :index |spaceAfterHeader at: index put: elem ]
 ]

--- a/src/Microdown-RichTextComposer/MicDynamicTextStyler.class.st
+++ b/src/Microdown-RichTextComposer/MicDynamicTextStyler.class.st
@@ -109,6 +109,7 @@ MicDynamicTextStyler >> headerFont: fontString forLevel: level [
 { #category : #initialization }
 MicDynamicTextStyler >> initialize [
 	self computeHeaderFonts. "super rely on lazy initilization"
+	bodyFont := nil.
 	bullets := '•-'.
 	counters := '1aA'.
 	interBlockSpacing := (String cr) asText.

--- a/src/Microdown-RichTextComposer/MicDynamicTextStyler.class.st
+++ b/src/Microdown-RichTextComposer/MicDynamicTextStyler.class.st
@@ -1,12 +1,38 @@
 "
-I am working in tandem with `MicFormatAnnotation` to allow control of the formatting of RichTextComposer within microdown.
+I am working in tandem with `MicRichTextFormatConfiguration` to allow control of the formatting of RichTextComposer within microdown.
 ```text
-{!format|
-hearder1Size=48&
-header1Font=Papyrus&
+{!richtext|
+headerFont4=Chalkduster;28&
 bullets=-÷·
 !}
 ```
+
+
+`FreeTypeFontProvider` can give access to all fonts on your system:
+```
+FreeTypeFontProvider current
+	updateFontsFromSystem;
+	updateAvailableFontFamilies.
+```
+
+## Examples:
+Bullets can be tailored: `{!richtext|bullets=xo!}` {!richtext|bullets=xo!}:
+- first level
+  - second level
+    - third level
+  - second level still
+- back to first
+
+
+Font sizes can be changed `{!richtext|headerFont3=Source Sans Pro;10&bodyFont=Source Sans Pro;7!}`
+{!richtext|headerFont3=Source Sans Pro;10&bodyFont=Source Sans Pro;7!}
+### Tiny header
+and very small body
+- first level
+  - second level
+    - third level
+  - second level still
+- back to first
 "
 Class {
 	#name : #MicDynamicTextStyler,
@@ -18,7 +44,8 @@ Class {
 		'newLineIfNotAlready',
 		'bodyFont',
 		'interBlockSpacing',
-		'crAfterHeader'
+		'crAfterHeader',
+		'keepCRFromInput'
 	],
 	#category : #'Microdown-RichTextComposer-Composer'
 }
@@ -90,17 +117,6 @@ MicDynamicTextStyler >> crAfterHeaders [
 	^ crAfterHeader 
 ]
 
-{ #category : #'as yet unclassified' }
-MicDynamicTextStyler >> getFont: fontString size: size [
-	| fileName |
-	fontString first = $§
-		ifFalse: [ ^ LogicalFont 
-						familyName: fontString 
-						pointSize: size].
-	fileName := fontString allButFirst.
-	^ FreeTypeFont fromFile: fileName pointSize: size
-]
-
 { #category : #'composer styles' }
 MicDynamicTextStyler >> headerFont: fontString forLevel: level [
 	|list font|
@@ -109,7 +125,9 @@ MicDynamicTextStyler >> headerFont: fontString forLevel: level [
 	list := (fontString splitOn: $;).
 	list size = 2 
 		ifFalse: [ MicParsingError signal: 'Font specs should be name;size - was: ',fontString  ].
-	font := self getFont: list first size: list second asNumber.
+	font := LogicalFont 
+			familyName: list first 
+			pointSize: list second asNumber.
 	headerFonts 
 		at: level 
 		put: (TextFontReference toFont:font)

--- a/src/Microdown-RichTextComposer/MicDynamicTextStyler.class.st
+++ b/src/Microdown-RichTextComposer/MicDynamicTextStyler.class.st
@@ -90,20 +90,29 @@ MicDynamicTextStyler >> crAfterHeaders [
 	^ crAfterHeader 
 ]
 
+{ #category : #'as yet unclassified' }
+MicDynamicTextStyler >> getFont: fontString size: size [
+	| fileName |
+	fontString first = $§
+		ifFalse: [ ^ LogicalFont 
+						familyName: fontString 
+						pointSize: size].
+	fileName := fontString allButFirst.
+	^ FreeTypeFont fromFile: fileName pointSize: size
+]
+
 { #category : #'composer styles' }
 MicDynamicTextStyler >> headerFont: fontString forLevel: level [
-	|list|
+	|list font|
 	(level between: 1 and: 6) 
 		ifFalse: [ MicParsingError signal: 'Header levels are 1 to 6 - got: ', level printString ].
 	list := (fontString splitOn: $;).
 	list size = 2 
 		ifFalse: [ MicParsingError signal: 'Font specs should be name;size - was: ',fontString  ].
+	font := self getFont: list first size: list second asNumber.
 	headerFonts 
 		at: level 
-		put: (TextFontReference
-				toFont:(LogicalFont 
-						familyName: list first
-						pointSize: list second asNumber))
+		put: (TextFontReference toFont:font)
 ]
 
 { #category : #initialization }

--- a/src/Microdown-RichTextComposer/MicDynamicTextStyler.class.st
+++ b/src/Microdown-RichTextComposer/MicDynamicTextStyler.class.st
@@ -1,0 +1,115 @@
+"
+I am working in tandem with `MicFormatAnnotation` to allow control of the formatting of RichTextComposer within microdown.
+```text
+{!format|
+hearder1Size=48&
+header1Font=Papyrus&
+bullets=-÷·
+!}
+```
+"
+Class {
+	#name : #MicDynamicTextStyler,
+	#superclass : #MicTextStyler,
+	#instVars : [
+		'bullets',
+		'counters',
+		'interblockSpacing',
+		'codeBackgroundColor',
+		'newLineIfNotAkready',
+		'defaultFont',
+		'spaceAfterHeader'
+	],
+	#category : #'Microdown-RichTextComposer-Composer'
+}
+
+{ #category : #initialization }
+MicDynamicTextStyler >> bulletForLevel: level [
+	^ ( bullets at: (level % bullets size)+1 ) asText.
+]
+
+{ #category : #accessing }
+MicDynamicTextStyler >> bullets: anObject [
+
+	bullets := anObject
+]
+
+{ #category : #accessing }
+MicDynamicTextStyler >> codeBackgroundColor: colorString [
+
+	codeBackgroundColor := Color fromString: colorString
+]
+
+{ #category : #'composer styles' }
+MicDynamicTextStyler >> counterFor: counter atLevel: level [
+	| kind |
+	kind := counters at: (level-1 % counters size)+1.
+	kind = $1
+		ifTrue: [ ^ counter asString asText , '.' ].
+	kind = $a
+		ifTrue: [ ^ ($a asInteger + (counter - 1)) asCharacter asText , ')' ].
+	kind = $A
+		ifTrue: [ ^ ($A asInteger + (counter - 1)) asCharacter asText , ')' ]
+]
+
+{ #category : #accessing }
+MicDynamicTextStyler >> counters: counterTypes [
+	"counter types are 1 (number), a (small letters), A (capital letters)"
+	counters := counterTypes
+]
+
+{ #category : #accessing }
+MicDynamicTextStyler >> defaultFont: anObject [
+
+	defaultFont := anObject
+]
+
+{ #category : #'composer styles' }
+MicDynamicTextStyler >> headerFont: fontString forLevel: level [
+	|list|
+	(level between: 1 and: 6) 
+		ifFalse: [ MicParsingError signal: 'Header levels are 1 to 6 - got: ', level printString ].
+	list := (fontString splitOn: $;).
+	list size = 2 
+		ifFalse: [ MicParsingError signal: 'Font specs should be name;size - was: ',fontString  ].
+	headerFonts 
+		at: level 
+		put: (LogicalFont 
+						familyName: list first
+						pointSize: list second asNumber)
+]
+
+{ #category : #initialization }
+MicDynamicTextStyler >> initialize [
+	self computeHeaderFonts. "super rely on lazy initilization"
+	bullets := '•-'.
+	counters := '1aA'.
+	interblockSpacing :=0.
+	codeBackgroundColor := Smalltalk ui theme settings windowColor.
+	newLineIfNotAkready :=0.
+	defaultFont := 0.
+	spaceAfterHeader := 0.
+]
+
+{ #category : #'composer styles' }
+MicDynamicTextStyler >> interblockSpacing: anObject [
+
+	interblockSpacing := anObject
+]
+
+{ #category : #'composer styles' }
+MicDynamicTextStyler >> monospaceBackgroundColor [
+	^ codeBackgroundColor 
+]
+
+{ #category : #'composer styles' }
+MicDynamicTextStyler >> newLineIfNotAkready: anObject [
+
+	newLineIfNotAkready := anObject
+]
+
+{ #category : #'composer styles' }
+MicDynamicTextStyler >> spaceAfterHeader: anObject [
+
+	spaceAfterHeader := anObject
+]

--- a/src/Microdown-RichTextComposer/MicRichTextCanvas.class.st
+++ b/src/Microdown-RichTextComposer/MicRichTextCanvas.class.st
@@ -18,9 +18,16 @@ Class {
 
 { #category : #public }
 MicRichTextCanvas >> << aText [
+	|text|
+	aText ifEmpty: [ ^ self ].
+	text := aText asText.
 	brushes do: [ :brush | brush paint: aText ].
-	out << aText.
-	aText ifNotEmpty: [crAtEnd := aText last = Character cr].
+	"If no font is already put, and a body font is defined, apply it"
+	((self hasFontDefinitions: text) not and: [ self textStyler bodyFont notNil])
+		ifTrue: [
+			text addAttribute: (TextFontReference toFont: self textStyler bodyFont)].
+	out << text.
+	text ifNotEmpty: [crAtEnd := text last = Character cr].
 ]
 
 { #category : #public }
@@ -31,6 +38,12 @@ MicRichTextCanvas >> contents [
 { #category : #public }
 MicRichTextCanvas >> cr [
 	self newLine
+]
+
+{ #category : #testing }
+MicRichTextCanvas >> hasFontDefinitions: aText [
+	"Answer the fontfor characters in the run beginning at characterIndex."
+	^ (aText runs flattened asSet select: [ :attr | attr isKindOf: TextFontReference  ]) isNotEmpty.
 ]
 
 { #category : #public }

--- a/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
+++ b/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
@@ -545,7 +545,9 @@ MicRichTextComposer >> visitRaw: aRawFormat [
 
 { #category : #visiting }
 MicRichTextComposer >> visitRichTextFormatConfiguration: config [
-	self textStyler: config styler
+	self textStyler class = MicDynamicTextStyler 
+		ifFalse: [ self textStyler: MicDynamicTextStyler new ].
+	config adjustStyler: self textStyler
 ]
 
 { #category : #'visiting -  format' }

--- a/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
+++ b/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
@@ -273,6 +273,7 @@ MicRichTextComposer >> textStyler [
 MicRichTextComposer >> textStyler: aTextStyler [
 
 	textStyler := aTextStyler.
+	canvas ifNotNil: [ canvas textStyler: aTextStyler  ]
 ]
 
 { #category : #private }
@@ -402,7 +403,7 @@ MicRichTextComposer >> visitHeader: aHeader [
 	canvas
 		includeAttribute: (self textStyler headerLevelFont: level)
 		in: [ super visitHeader: aHeader ].
-	canvas << (textStyler spaceAfterHeaderLevel: level)
+	canvas << (textStyler crAfterHeaderLevel: level)
 ]
 
 { #category : #'visiting - document' }
@@ -499,7 +500,7 @@ MicRichTextComposer >> visitOrderedList: aList [
 				item propertyAt: #kind put: #ordered.
 				item
 					propertyAt: #counter
-					put: (self textStyler counterFor: counter atLevel: canvas nesting - 1).
+					put: (self textStyler counterFor: counter atLevel: (canvas nesting // 2) - 1).
 				counter := counter + 1 ].
 		super visitOrderedList: aList ].
 	canvas newLine.
@@ -511,7 +512,7 @@ MicRichTextComposer >> visitParagraph: anObject [
 	
 	canvas newLineIfNotAlready.
 	super visitParagraph: anObject.
-	canvas newLine; << textStyler interBlockSpacing 
+	canvas << textStyler interBlockSpacing 
 ]
 
 { #category : #'visiting - document' }
@@ -534,6 +535,11 @@ MicRichTextComposer >> visitQuote: aQuote [
 MicRichTextComposer >> visitRaw: aRawFormat [
 
 	canvas << aRawFormat substring asText.
+]
+
+{ #category : #visiting }
+MicRichTextComposer >> visitRichTextFormatConfiguration: config [
+	self textStyler: config styler
 ]
 
 { #category : #'visiting -  format' }
@@ -574,7 +580,9 @@ MicRichTextComposer >> visitTable: tableBlock [
 { #category : #'visiting -  format' }
 MicRichTextComposer >> visitText: anInlineBlock [
 	"we should set attribute because it would override link and others."
-	canvas << (textStyler postTextTreatment: (anInlineBlock substring asText) )
+	|text|
+	text := (anInlineBlock substring asText) addAttribute: (TextFontReference toFont: self textStyler bodyFont).
+	canvas << (textStyler postTextTreatment: text )
 ]
 
 { #category : #'visiting - list' }
@@ -587,7 +595,8 @@ MicRichTextComposer >> visitUnorderedList: aList [
 					item propertyAt: #kind put: #unordered.
 					item
 						propertyAt: #bullet
-						put: (self textStyler bulletForLevel: canvas nesting - 1) ].
+						"outer level has nesting 1, second level has nesting 3, third level has has nesting 5"
+						put: (self textStyler bulletForLevel: (canvas nesting//2) + 1) ].
 			super visitUnorderedList: aList ].
 	canvas newLine.
 	aList nestedLevel = 1 ifTrue: [ canvas << textStyler interBlockSpacing] 

--- a/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
+++ b/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
@@ -256,6 +256,12 @@ MicRichTextComposer >> latexFor: aString onError: aBlock [
 ]
 
 { #category : #private }
+MicRichTextComposer >> level [
+	"level is the logical indention level of lists. Outer list is indented 1, next is indented 3, etc."
+	^(canvas nesting // 2) +1
+]
+
+{ #category : #private }
 MicRichTextComposer >> renderTableCell: aCell [
 	"a cell is an array of nodes. Each element should be rendered and concatenated"
 	^ aCell inject: Text new into: [ :txt :part | 
@@ -496,11 +502,11 @@ MicRichTextComposer >> visitOrderedList: aList [
 	canvas newLineIfNotAlready.
 	canvas indentIn: [counter := 1.
 		aList children
-			do: [ :item | 
+			do: [ :item |
 				item propertyAt: #kind put: #ordered.
 				item
 					propertyAt: #counter
-					put: (self textStyler counterFor: counter atLevel: (canvas nesting // 2) - 1).
+					put: (self textStyler counterFor: counter atLevel: self level).
 				counter := counter + 1 ].
 		super visitOrderedList: aList ].
 	canvas newLine.
@@ -595,8 +601,7 @@ MicRichTextComposer >> visitUnorderedList: aList [
 					item propertyAt: #kind put: #unordered.
 					item
 						propertyAt: #bullet
-						"outer level has nesting 1, second level has nesting 3, third level has has nesting 5"
-						put: (self textStyler bulletForLevel: (canvas nesting//2) + 1) ].
+						put: (self textStyler bulletForLevel: self level) ].
 			super visitUnorderedList: aList ].
 	canvas newLine.
 	aList nestedLevel = 1 ifTrue: [ canvas << textStyler interBlockSpacing] 

--- a/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
+++ b/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
@@ -587,7 +587,10 @@ MicRichTextComposer >> visitTable: tableBlock [
 MicRichTextComposer >> visitText: anInlineBlock [
 	"we should set attribute because it would override link and others."
 	|text|
-	text := (anInlineBlock substring asText) addAttribute: (TextFontReference toFont: self textStyler bodyFont).
+	text := anInlineBlock substring asText.
+	self textStyler bodyFont 
+		ifNotNil: [ 
+			text addAttribute: (TextFontReference toFont: self textStyler bodyFont)].
 	canvas << (textStyler postTextTreatment: text )
 ]
 

--- a/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
+++ b/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
@@ -306,7 +306,7 @@ MicRichTextComposer >> visit: aDocument [
 		          textStyler: self textStyler;
 		          yourself.
 	super visit: aDocument.
-	^ canvas contents
+	^ canvas contents trim
 ]
 
 { #category : #'visiting - document' }

--- a/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
+++ b/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
@@ -590,9 +590,6 @@ MicRichTextComposer >> visitText: anInlineBlock [
 	"we should set attribute because it would override link and others."
 	|text|
 	text := anInlineBlock substring asText.
-	self textStyler bodyFont 
-		ifNotNil: [ 
-			text addAttribute: (TextFontReference toFont: self textStyler bodyFont)].
 	canvas << (textStyler postTextTreatment: text )
 ]
 

--- a/src/Microdown-RichTextComposer/MicRichTextFormatConfiguration.class.st
+++ b/src/Microdown-RichTextComposer/MicRichTextFormatConfiguration.class.st
@@ -19,9 +19,6 @@ I support the following arguments: {!richtext|bullets=◊»!}
 Class {
 	#name : #MicRichTextFormatConfiguration,
 	#superclass : #MicAnnotationBlock,
-	#instVars : [
-		'styler'
-	],
 	#category : #'Microdown-RichTextComposer-Composer'
 }
 
@@ -36,10 +33,9 @@ MicRichTextFormatConfiguration >> accept: visitor [
 ]
 
 { #category : #visiting }
-MicRichTextFormatConfiguration >> closeMe [
+MicRichTextFormatConfiguration >> adjustStyler: styler [
 	| setters |
-	styler := MicDynamicTextStyler new.
-	setters := self setterDictionary.
+	setters := self setterDictionaryFor: styler.
 	arguments justTheArguments  keysAndValuesDo: [ :key :value |
 		setters at: key 
 			ifPresent: [ :block | block value: value]
@@ -48,7 +44,7 @@ MicRichTextFormatConfiguration >> closeMe [
 ]
 
 { #category : #private }
-MicRichTextFormatConfiguration >> setterDictionary [
+MicRichTextFormatConfiguration >> setterDictionaryFor: styler [
 	^ {	
 	'bullets' -> [ :a | styler bullets: a].
 	'counters' -> [ :a | styler counters: a].
@@ -64,9 +60,4 @@ MicRichTextFormatConfiguration >> setterDictionary [
 	'headerFont5' -> [ :a | styler headerFont: a forLevel: 5].
 	'headerFont6' -> [ :a | styler headerFont: a forLevel: 6].
 	} asDictionary
-]
-
-{ #category : #accessing }
-MicRichTextFormatConfiguration >> styler [
-	^ styler 
 ]

--- a/src/Microdown-RichTextComposer/MicRichTextFormatConfiguration.class.st
+++ b/src/Microdown-RichTextComposer/MicRichTextFormatConfiguration.class.st
@@ -52,6 +52,7 @@ MicRichTextFormatConfiguration >> setterDictionaryFor: styler [
 	'crAfterHeader' -> [ :a | styler crAfterHeader: a].
 	'monospaceBackgroundColor' -> [ :a | styler monospaceBackgroundColor: a].
 	'newLineIfNotAlready' -> [ :a | styler newLineIfNotAlready: a].
+	'keepCRFromInput' -> [ :a | styler keepCRFromInput: a ].
 	'bodyFont' -> [ :a | styler bodyFont: a].
 	'headerFont1' -> [ :a | styler headerFont: a forLevel: 1].
 	'headerFont2' -> [ :a | styler headerFont: a forLevel: 2].

--- a/src/Microdown-RichTextComposer/MicRichTextFormatConfiguration.class.st
+++ b/src/Microdown-RichTextComposer/MicRichTextFormatConfiguration.class.st
@@ -1,0 +1,72 @@
+"
+I am a block that holds a MicDynamicTextStyler, gettings its values from a MicArgumentList.
+I support the following arguments: {!richtext|bullets=◊»!}
+- bodyFont
+- bullets
+- counters
+- header fonts
+  - headerFont1
+  - headerFont2
+  - headerFont3
+  - headerFont4
+  - headerFont5
+  - headerFont6
+- interblockSpacing
+- monospaceBackgroundColor
+- newLineIfNotAlready
+- spaceAfterHeader
+"
+Class {
+	#name : #MicRichTextFormatConfiguration,
+	#superclass : #MicAnnotationBlock,
+	#instVars : [
+		'styler'
+	],
+	#category : #'Microdown-RichTextComposer-Composer'
+}
+
+{ #category : #accessing }
+MicRichTextFormatConfiguration class >> tag [
+	^ #richtext
+]
+
+{ #category : #visiting }
+MicRichTextFormatConfiguration >> accept: visitor [
+	visitor visitRichTextFormatConfiguration: self
+]
+
+{ #category : #visiting }
+MicRichTextFormatConfiguration >> closeMe [
+	| setters |
+	styler := MicDynamicTextStyler new.
+	setters := self setterDictionary.
+	arguments justTheArguments  keysAndValuesDo: [ :key :value |
+		setters at: key 
+			ifPresent: [ :block | block value: value]
+			ifAbsent: [ MicParsingError signal: 'richtext annotation - unknown argument: ', key ]
+		 ].
+]
+
+{ #category : #private }
+MicRichTextFormatConfiguration >> setterDictionary [
+	^ {	
+	'bullets' -> [ :a | styler bullets: a].
+	'counters' -> [ :a | styler counters: a].
+	'interBlockSpacing' -> [ :a | styler interBlockSpacing: a].
+	'crAfterHeader' -> [ :a | styler crAfterHeader: a].
+	'monospaceBackgroundColor' -> [ :a | styler monospaceBackgroundColor: a].
+	'newLineIfNotAlready' -> [ :a | styler newLineIfNotAlready: a].
+	'bodyFont' -> [ :a | styler bodyFont: a].
+	'headerFont1' -> [ :a | styler headerFont: a forLevel: 1].
+	'headerFont2' -> [ :a | styler headerFont: a forLevel: 2].
+	'headerFont3' -> [ :a | styler headerFont: a forLevel: 3].
+	'headerFont4' -> [ :a | styler headerFont: a forLevel: 4].
+	'headerFont5' -> [ :a | styler headerFont: a forLevel: 5].
+	'headerFont6' -> [ :a | styler headerFont: a forLevel: 6].
+	} asDictionary
+]
+
+{ #category : #accessing }
+MicRichTextFormatConfiguration >> styler [
+	^ styler 
+]

--- a/src/Microdown-RichTextComposer/MicTextStyler.class.st
+++ b/src/Microdown-RichTextComposer/MicTextStyler.class.st
@@ -16,12 +16,13 @@ Class {
 
 { #category : #'presenter styles' }
 MicTextStyler >> bodyFont [
-	^ LogicalFont familyName: 'Source Sans Pro' pointSize: 80
+	^ nil
 ]
 
 { #category : #'composer styles' }
 MicTextStyler >> bulletForLevel: level [
-	^ ('•-' at: (level % 2)+1) asText
+	"first level is 1, then 2, then 3..."
+	^ ('•-' at: (level-1 % 2)+1) asText
 ]
 
 { #category : #private }
@@ -41,13 +42,14 @@ MicTextStyler >> computeHeaderFonts [
 { #category : #'composer styles' }
 MicTextStyler >> counterFor: counter atLevel: level [
 	| kind |
+	"first level is 1"
 	kind := level % 3.
-	kind = 0
-		ifTrue: [ ^ counter asString asText , '.' ].
 	kind = 1
-		ifTrue: [ ^ ($a asInteger + (counter - 1)) asCharacter asText , ')' ].
+		ifTrue: [ ^ counter asString asText , '.' ].
 	kind = 2
-		ifTrue: [ ^ ($A asInteger + (counter - 1)) asCharacter asText , ')' ]
+		ifTrue: [ ^ ($A asInteger + (counter - 1)) asCharacter asText , ')' ].
+	kind = 0
+		ifTrue: [ ^ ($a asInteger + (counter - 1)) asCharacter asText , ')' ]
 ]
 
 { #category : #'composer styles' }
@@ -70,8 +72,8 @@ MicTextStyler >> headerLevelFont: level [
 
 { #category : #'composer styles' }
 MicTextStyler >> interBlockSpacing [
-	"I return the space to be put between blocks"
-	^ String cr asText
+	"I return the space to be put between blocks, first cr to end block, second to make empty line"
+	^ (String cr, String cr) asText
 ]
 
 { #category : #'composer styles' }

--- a/src/Microdown-RichTextComposer/MicTextStyler.class.st
+++ b/src/Microdown-RichTextComposer/MicTextStyler.class.st
@@ -14,14 +14,14 @@ Class {
 	#category : #'Microdown-RichTextComposer-Composer'
 }
 
+{ #category : #'presenter styles' }
+MicTextStyler >> bodyFont [
+	^ LogicalFont familyName: 'Source Sans Pro' pointSize: 80
+]
+
 { #category : #'composer styles' }
 MicTextStyler >> bulletForLevel: level [
-	| kind |
-	kind := level % 2.
-	kind = 0
-		ifTrue: [ ^ $• asText ].
-	kind = 1
-		ifTrue: [ ^ $- asText ]
+	^ ('•-' at: (level % 2)+1) asText
 ]
 
 { #category : #private }
@@ -48,6 +48,12 @@ MicTextStyler >> counterFor: counter atLevel: level [
 		ifTrue: [ ^ ($a asInteger + (counter - 1)) asCharacter asText , ')' ].
 	kind = 2
 		ifTrue: [ ^ ($A asInteger + (counter - 1)) asCharacter asText , ')' ]
+]
+
+{ #category : #'composer styles' }
+MicTextStyler >> crAfterHeaderLevel: level [
+	"I return Text to make space after a header"
+	^ String cr asText
 ]
 
 { #category : #public }
@@ -94,15 +100,4 @@ MicTextStyler >> postTextTreatment: aText [
 		do: [ :i | aText at: i put: Character space ]."
 	^ aText
 	 
-]
-
-{ #category : #'presenter styles' }
-MicTextStyler >> presenterDefaultFont [
-	^ LogicalFont familyName: 'Source Sans Pro' pointSize: 80
-]
-
-{ #category : #'composer styles' }
-MicTextStyler >> spaceAfterHeaderLevel: level [
-	"I return Text to make space after a header"
-	^ String cr asText
 ]

--- a/src/Microdown-RichTextComposer/MicrodownVisitor.extension.st
+++ b/src/Microdown-RichTextComposer/MicrodownVisitor.extension.st
@@ -2,5 +2,5 @@ Extension { #name : #MicrodownVisitor }
 
 { #category : #'*Microdown-RichTextComposer' }
 MicrodownVisitor >> visitRichTextFormatConfiguration: config [
-	super visitAnnotation: config
+	self visitAnnotation: config
 ]

--- a/src/Microdown-RichTextComposer/MicrodownVisitor.extension.st
+++ b/src/Microdown-RichTextComposer/MicrodownVisitor.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #MicrodownVisitor }
+
+{ #category : #'*Microdown-RichTextComposer' }
+MicrodownVisitor >> visitRichTextFormatConfiguration: config [
+	super visitAnnotation: config
+]

--- a/src/Microdown-RichTextComposer/Text.extension.st
+++ b/src/Microdown-RichTextComposer/Text.extension.st
@@ -1,0 +1,16 @@
+Extension { #name : #Text }
+
+{ #category : #'*Microdown-RichTextComposer' }
+Text >> trim [
+	| left right |
+	left := 1.
+	right := self size.
+	
+	[ left <= right and: [ (self at: left) isSeparator  ] ]
+		whileTrue: [ left := left + 1 ].
+		
+	[ left <= right and: [ (self at: right) isSeparator ] ]
+		whileTrue: [ right := right - 1 ].
+		
+	^ self copyFrom: left to: right
+]


### PR DESCRIPTION
This PR is cool, it allow us to adjust font and spacings of the RichTextComposer from within Microdown using an extension.
To get really large header level 1, and larger body font you can write:
```
{!richtext|headerFont1=Lucida Grande;72&bodyFont=Lucida Grande;24!}
# Huge header
and large body
```
<img width="604" alt="image" src="https://user-images.githubusercontent.com/17723745/175800927-a13640ed-1dfd-4468-a926-6b7e7c0214ab.png">

I think it will be rather useful for slides