### PR TITLE
Fixes #519 Microdown directory resolution

### DIFF
--- a/src/Microdown-Tests/MicFileResourceReferenceTest.class.st
+++ b/src/Microdown-Tests/MicFileResourceReferenceTest.class.st
@@ -126,6 +126,8 @@ MicFileResourceReferenceTest >> setUp [
 	file := filesystem workingDirectory / 'toplevel.png'.
 	PNGReadWriter putForm: image onStream: file binaryWriteStream.
 	
+	(filesystem workingDirectory / 'subdir') ensureCreateDirectory.
+	
 ]
 
 { #category : #tests }
@@ -174,6 +176,15 @@ MicFileResourceReferenceTest >> testFileReferenceExtensionMethod [
 ]
 
 { #category : #tests }
+MicFileResourceReferenceTest >> testFileReferenceExtensionMethod_dir [
+	| fileRef micRef |
+	fileRef := (filesystem workingDirectory / '/subdir') asFileReference.
+	micRef := fileRef asMicResourceReference.
+	self assert: micRef isDirectory.
+	self assert: (micRef uri printString endsWith: '/')
+]
+
+{ #category : #tests }
 MicFileResourceReferenceTest >> testIsDirectory [ 
 	| ref |
 	ref := filesystem workingDirectory asMicResourceReference.
@@ -185,7 +196,7 @@ MicFileResourceReferenceTest >> testLoadChildren [
 	| ref files |
 	ref := filesystem workingDirectory asMicResourceReference.
 	files := ref loadChildren.
-	self assert: files size equals: 2.
+	self assert: files size equals: 3.
 	self assert: files first class equals: MicFileResourceReference
 ]
 

--- a/src/Microdown/MicFileResourceReference.class.st
+++ b/src/Microdown/MicFileResourceReference.class.st
@@ -28,8 +28,12 @@ Class {
 { #category : #'instance creation' }
 MicFileResourceReference class >> fromFileRef: aFileReference [
 	"return an instance of me which references aFileReference"
+	| znUrl |
+	znUrl := aFileReference asZnUrl.
+	aFileReference isDirectory 
+		ifTrue: [ znUrl addPathSegment: $/ "Yes, a Character not a string" ].
 	^ self new
-		uri: aFileReference asZnUrl;
+		uri: znUrl;
 		filesystem: aFileReference fileSystem 
 ]
 


### PR DESCRIPTION
@Ducasse - I think this PR fixes the issue we found yeasterday

'/Users/kasper/tmp' asFileReference asMicResourceReference uri withRelativeReference: 'foo/my.md' now returns 'file:///Users/kasper/tmp/foo/my.md'.
Fix is done in `MicFileResourceReference>>#fromFileRef:`