### PR TITLE
Fixes #556, allowing tabs to be preserved in code blocks (and elsewhere)

### DIFF
--- a/src/Microdown-HTMLExporter-Tests/MicHTMLVisitorTest.class.st
+++ b/src/Microdown-HTMLExporter-Tests/MicHTMLVisitorTest.class.st
@@ -88,16 +88,15 @@ MicHTMLVisitorTest >> testContents [
 
 { #category : #tests }
 MicHTMLVisitorTest >> testConvertMicFile [
-	
+
 	writer convertMicFile: (fileSystem / 'anExample1.md') asFileReference.
-	
+
 	self assert: (fileSystem / 'anExample1.html') asFileReference exists.
-	self 
-		assert: (fileSystem / 'anExample1.html') asFileReference contents 
-		equals: newLine ,
-'<h1>Foo</h1><a id="sec1"></a>', newLine ,
-'<p>Pharo is cool</p>', newLine ,
-'<pre><code> this is a code blu blu</code></pre>', newLine
+	self
+		assert: (fileSystem / 'anExample1.html') asFileReference contents
+		equals: newLine , '<h1>Foo</h1><a id="sec1"></a>' , newLine
+			, '<p>Pharo is cool</p>' , newLine
+			, '<pre><code>	this is a code blu blu</code></pre>' , newLine
 ]
 
 { #category : #tests }

--- a/src/Microdown-LaTeXExporter-Tests/MicSBALaTeXWriterTest.class.st
+++ b/src/Microdown-LaTeXExporter-Tests/MicSBALaTeXWriterTest.class.st
@@ -41,12 +41,17 @@ MicSBALaTeXWriterTest >> testCodeblockWithCaption [
 { #category : #tests }
 MicSBALaTeXWriterTest >> testCodeblockWithChevron [
 
-	self writeFor: (factory codeblock: 'caption=Pharo is **cool**' body: 'MyClass >> foo
-	this is a code').
-	self assert: writer contents equals: '\begin{listing}[float]{smalltalk}{Pharo is \textbf{cool}}', newLine ,
-													'MyClass >> foo', newLine ,
-													' this is a code', newLine ,
-													'\end{listing}', newLine
+	self writeFor:
+		(factory
+			 codeblock: 'caption=Pharo is **cool**'
+			 body: 'MyClass >> foo
+ this is a code').
+	self
+		assert: writer contents
+		equals:
+			'\begin{listing}[float]{smalltalk}{Pharo is \textbf{cool}}'
+			, newLine , 'MyClass >> foo' , newLine , ' this is a code'
+			, newLine , '\end{listing}' , newLine
 ]
 
 { #category : #tests }

--- a/src/Microdown-PrettyPrinter-Tests/MicTextualMicrodownExporterTest.class.st
+++ b/src/Microdown-PrettyPrinter-Tests/MicTextualMicrodownExporterTest.class.st
@@ -85,14 +85,14 @@ MicTextualMicrodownExporterTest >> testCodeBlock [
 
 { #category : #'tests-codeblock' }
 MicTextualMicrodownExporterTest >> testCodeBlockNewLine [
-	
+
 	| mic |
 	mic := parser parse: '```
 	this is a codeblock
 ```'.
 	self assert: (mic accept: visitor) contents equals: '
 ```
- this is a codeblock
+	this is a codeblock
 ```
 '
 ]

--- a/src/Microdown-RichTextComposer-Tests/MicRichTextComposerTest.class.st
+++ b/src/Microdown-RichTextComposer-Tests/MicRichTextComposerTest.class.st
@@ -277,6 +277,21 @@ line 2
 Roger Rabbit'
 ]
 
+{ #category : #'tests - codeBlock' }
+MicRichTextComposerTest >> testCodeBlockWithTabbedCode [
+
+	| source richText |
+	source := '
+```
+7
+	8
+```
+'.
+	richText := self richTextForString: source.
+	self assert: richText asString trim equals: '7
+	8'
+]
+
 { #category : #tests }
 MicRichTextComposerTest >> testEnvironment_unknownShouldNotFail [
 	| src |

--- a/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
+++ b/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
@@ -382,7 +382,6 @@ MicRichTextComposer >> visitCenter: aMicCenterBlock [
 
 { #category : #visiting }
 MicRichTextComposer >> visitCode: aCodeBlock [
-
 	canvas newLineIfNotAlready.
 	canvas indentIn: [ 
 		canvas

--- a/src/Microdown-Tests/MicMicrodownSnippetFactory.class.st
+++ b/src/Microdown-Tests/MicMicrodownSnippetFactory.class.st
@@ -634,11 +634,11 @@ MicMicrodownSnippetFactory >> nestedOrderedList2Sample [
 	^ '
 - Foo
 - Bar
-		1. B
-		1. a
-		1. r
-					- 3rdlvel
-					- 3rdlevl2
+  1. B
+  1. a
+  1. r
+     - 3rdlvel
+     - 3rdlevl2
 - Zork
 '
 ]
@@ -648,9 +648,9 @@ MicMicrodownSnippetFactory >> nestedOrderedListSample [
 	^ '
 - Foo
 - Bar
-		1. B
-		1. a
-		1. r
+  1. B
+  1. a
+  1. r
 '
 ]
 
@@ -659,9 +659,9 @@ MicMicrodownSnippetFactory >> nestedUnorderedListSample [
 	^ '
 - Foo
 - Bar
-		- B
-		- a
-		- r
+  - B
+  - a
+  - r
 '
 ]
 

--- a/src/Microdown/MicrodownParser.class.st
+++ b/src/Microdown/MicrodownParser.class.st
@@ -226,22 +226,18 @@ MicrodownParser >> delimiterBlockClassFor: prefix [
 
 { #category : #parsing }
 MicrodownParser >> handleLine: line [
+
 	"The logic is the following: 
-		-first line is cleaned to avoid noise,
-		-then if the current block can consume the line, it manages it and this potentially creates a new block that becomes the current one.
+		-if the current block can consume the line, it manages it and this potentially creates a new block that becomes the current one.
 		When the line is not consumed, the current block is closed and its parent becomes the current one and the process is called back to treat the line."
-		
-	| normalized |
-	normalized := line copyReplaceAll: String tab with: String space.
-	 
-	(current canConsumeLine: normalized)
+
+	(current canConsumeLine: line)
 		ifTrue: [ 
-			current := current addLineAndReturnNextNode: normalized.
+			current := current addLineAndReturnNextNode: line.
 			^ current ]
-		ifFalse: [ 
-			current closeMe ].
+		ifFalse: [ current closeMe ].
 	current := current parent.
-	self handleLine: normalized
+	self handleLine: line
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
Notice that this change impacted a number of tests in latex and html. Before it was possible to write nested lists using tabs rather than space, not anymore. 
Personally I think it was a good idea anyways as it is easier to see that the indentation of nested lists fits the rules of the parser.