### PR TITLE
Changed all .mic to .md

### DIFF
--- a/src/Microdown-HTMLExporter/MicHTMLStylerOpenCommand.class.st
+++ b/src/Microdown-HTMLExporter/MicHTMLStylerOpenCommand.class.st
@@ -40,7 +40,7 @@ MicHTMLStylerOpenCommand class >> order [
 { #category : #executing }
 MicHTMLStylerOpenCommand >> execute [
 
-	(self requestFileNameForOpen: '*.mic')
+	(self requestFileNameForOpen: '*.md')
 		ifNotNil: [ : answer | 
 			(self isValidMic: answer)
 				ifTrue: [ self context micDocumentFileRef: answer asFileReference ]

--- a/src/Microdown-Tests/MicEnvironmentBlockTest.class.st
+++ b/src/Microdown-Tests/MicEnvironmentBlockTest.class.st
@@ -314,27 +314,27 @@ toto'.
 MicEnvironmentBlockTest >> testInputFileOnOneLineWithJunkAfter [
 
 	| mic infileReference |
-	mic := parser parse: EnvironmentOpeningBlockMarkup, 'inputFile|path=chapters/withStyle.mic', EnvironmentClosingBlockMarkup, String space, 'lkjkljklj'.
+	mic := parser parse: EnvironmentOpeningBlockMarkup, 'inputFile|path=chapters/withStyle.md', EnvironmentClosingBlockMarkup, String space, 'lkjkljklj'.
 	infileReference := mic children first path.
-	self assert: infileReference path equals: 'chapters/withStyle.mic' 
+	self assert: infileReference path equals: 'chapters/withStyle.md' 
 ]
 
 { #category : #'tests - better parsing' }
 MicEnvironmentBlockTest >> testInputFileOnOneLineWithJunkSpaceBeforeEnd [
 
 	| mic infileReference |
-	mic := parser parse: EnvironmentOpeningBlockMarkup, 'inputFile|path=chapters/withStyle.mic     ', EnvironmentClosingBlockMarkup.
+	mic := parser parse: EnvironmentOpeningBlockMarkup, 'inputFile|path=chapters/withStyle.md     ', EnvironmentClosingBlockMarkup.
 	infileReference := mic children first path.
-	self assert: infileReference path equals: 'chapters/withStyle.mic' 
+	self assert: infileReference path equals: 'chapters/withStyle.md'
 ]
 
 { #category : #'tests - better parsing' }
 MicEnvironmentBlockTest >> testInputFileOnOneLineWithSpaceBeforeJunkAfter [
 
 	| mic infileReference |
-	mic := parser parse: EnvironmentOpeningBlockMarkup, 'inputFile|path=chapters/withStyle.mic  ', EnvironmentClosingBlockMarkup, String space, 'lkjkljklj'.
+	mic := parser parse: EnvironmentOpeningBlockMarkup, 'inputFile|path=chapters/withStyle.md  ', EnvironmentClosingBlockMarkup, String space, 'lkjkljklj'.
 	infileReference := mic children first path.
-	self assert: infileReference path equals: 'chapters/withStyle.mic' 
+	self assert: infileReference path equals: 'chapters/withStyle.md' 
 ]
 
 { #category : #'tests - default environment' }

--- a/src/Microdown-Tests/MicResourceReferenceTest.class.st
+++ b/src/Microdown-Tests/MicResourceReferenceTest.class.st
@@ -31,17 +31,17 @@ MicResourceReferenceTest >> testIsDirectory [
 MicResourceReferenceTest >> testParseFullUrl [
 
 	| mf |
-	mf := self resourceClass fromUri: 'http://server/m.mic'.
-	self assert: mf uriString equals: 'http://server/m.mic'.
+	mf := self resourceClass fromUri: 'http://server/m.md'.
+	self assert: mf uriString equals: 'http://server/m.md'.
 
 ]
 
 { #category : #'tests - file reference conversion' }
 MicResourceReferenceTest >> testPurePathInterpretedAsFile [
 	| mf |
-	mf := self resourceClass fromUri: '/chapter1/figures/m.mic'.
+	mf := self resourceClass fromUri: '/chapter1/figures/m.md'.
 	self assert: mf isFileReference.
-	self assert: mf fullName equals: '/chapter1/figures/m.mic'.
+	self assert: mf fullName equals: '/chapter1/figures/m.md'.
 	
 ]
 
@@ -49,9 +49,9 @@ MicResourceReferenceTest >> testPurePathInterpretedAsFile [
 MicResourceReferenceTest >> testPurePathIsRelativeFile [
 	
 	| mf |
-	mf := self resourceClass fromUri: 'chapter1/figures/m.mic'.
+	mf := self resourceClass fromUri: 'chapter1/figures/m.md'.
 	self assert: mf isRelative.
-	self assert: mf relativePath equals: 'chapter1/figures/m.mic'.
+	self assert: mf relativePath equals: 'chapter1/figures/m.md'.
 	
 ]
 
@@ -59,9 +59,9 @@ MicResourceReferenceTest >> testPurePathIsRelativeFile [
 MicResourceReferenceTest >> testRelativeFileRecognized [
 	
 	| mf |
-	mf := self resourceClass fromUri: 'chapter1/figures/m.mic'.
+	mf := self resourceClass fromUri: 'chapter1/figures/m.md'.
 	self assert: mf isRelative.
-	self assert: mf relativePath equals: 'chapter1/figures/m.mic'.
+	self assert: mf relativePath equals: 'chapter1/figures/m.md'.
 	
 ]
 

--- a/src/Microdown-Tests/MicrodownParserTest.class.st
+++ b/src/Microdown-Tests/MicrodownParserTest.class.st
@@ -417,9 +417,9 @@ MicrodownParserTest >> testParseEmpty [
 
 	| file system mic |
 	system := FileSystem memory workingDirectory.
-	file := system / 'test.mic'.
+	file := system / 'test.md'.
 	(system / 'folder') createDirectory.
-	file := system / 'folder/file.mic'.
+	file := system / 'folder/file.md'.
 	file writeStreamDo: [ :stream | stream nextPutAll: '' ].
 	mic := parser parse: file asFileReference contents.
 	self assert: mic children isEmpty. 

--- a/src/Microdown/MicAnchorReferenceBlock.class.st
+++ b/src/Microdown/MicAnchorReferenceBlock.class.st
@@ -58,7 +58,7 @@ MicAnchorReferenceBlock >> referenceAsHTML [
 	| ref |
 	self flag: #todo.
 	ref := self reference.
-	(ref endsWith: '.mic')
+	(ref endsWith: '.md')
 		ifTrue: [ ref := (ref copyUpToLast: $.) , '.html' ]
 		ifFalse: [ Error signal: 'Reference : ' , ref , ' should end with .pillar or .pier' ].
 	^ ref


### PR DESCRIPTION
Yay - a meta programming exercise - fixed these methods
```smalltalk
(((RPackage organizer packages select: [ :p | 
		     p name beginsWith: 'Microdown' ]) collect: #classes) flattened 
		   collect: [ :cl | cl methodDictionary values ]) flattened 
		select: [ :cm | 
		  cm ast allChildren anySatisfy: [ :e | 
			  (e isLiteralNode and: [ e value isString ]) and: [ 
				  e value asLowercase includesSubstring: '.mic' ] ] ]
```