### PR TITLE
Fixes #567, MicMathInlineBlock comment does not render

### DIFF
--- a/src/Microdown-Tests/MicrodownInlineParserTest.class.st
+++ b/src/Microdown-Tests/MicrodownInlineParserTest.class.st
@@ -414,6 +414,14 @@ MicrodownInlineParserTest >> testMonospacesWithDoubleBackSlash [
 ]
 
 { #category : #'tests - format' }
+MicrodownInlineParserTest >> testMonospacesWithTwoBackslashes [
+ 	| elements |
+ 	elements := self parseAndReturnElementsOfParagraphFor: '`\a+\b`'.
+ 	self assert: elements size equals: 1.
+ 	self assert: elements first substring equals: '\a+\b'
+]
+
+{ #category : #'tests - format' }
 MicrodownInlineParserTest >> testMonospacesWithoutClosure [
  	| elements |
  	elements := self parseAndReturnElementsOfParagraphFor: 'abc`monospacesdef'.

--- a/src/Microdown/MicInlineParser.class.st
+++ b/src/Microdown/MicInlineParser.class.st
@@ -129,7 +129,7 @@ MicInlineParser class >> magicCharacter [
 
 { #category : #'handle basic text' }
 MicInlineParser >> addATextFrom: start to: end toFinalArray: aFinalArray [
-	start > end
+	(start > end or: [end > string size])
 		ifTrue: [ " do nothing "]
 		ifFalse: [ aFinalArray add: (self newBasicInlineBlockFrom: start to: end ) ]
 ]

--- a/src/Microdown/MicMathInlineBlock.class.st
+++ b/src/Microdown/MicMathInlineBlock.class.st
@@ -42,7 +42,7 @@ MicMathInlineBlock >> accept: aVisitor [
 
 { #category : #operations }
 MicMathInlineBlock >> cleanSubstring [
-	self substring: (MicInlineParser escapeReescape: self substring  except: '')
+	self substring: (MicInlineParser escapeReescape: self substring  except: '$')
 ]
 
 { #category : #accessing }

--- a/src/Microdown/MicMonospaceFormatBlock.class.st
+++ b/src/Microdown/MicMonospaceFormatBlock.class.st
@@ -17,9 +17,19 @@ MicMonospaceFormatBlock >> accept: aVisitor [
 	^ aVisitor visitMonospace: self
 ]
 
-{ #category : #operations }
-MicMonospaceFormatBlock >> cleanSubstring [
-	self substring: (MicInlineParser escapeReescape: self substring except: '`')
+{ #category : #visiting }
+MicMonospaceFormatBlock >> closeMe [
+	
+	| text decodedString |
+	decodedString := MicInlineParser escapeReescape: substring except: '`'.
+	self substring: decodedString.
+	children ifEmpty: [
+			text :=  (MicTextBlock
+							from: start
+							to: end
+							withSubstring: decodedString 
+							withChildren: Array empty).
+			self children: { text } ]
 ]
 
 { #category : #internal }

--- a/src/Microdown/MicRootBlock.class.st
+++ b/src/Microdown/MicRootBlock.class.st
@@ -65,4 +65,3 @@ MicRootBlock >> properties: aConfigurationForPillar [
 	properties keysAndValuesDo: [ :k :v | aConfigurationForPillar at: k put: v ].
 	properties := aConfigurationForPillar
 ]
-


### PR DESCRIPTION
This fix seems to patch the inline parser. 
I did not load the full microdown at this one, so full tests pending