### PR TITLE
This patches the error of rubrics

### DIFF
--- a/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
+++ b/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
@@ -326,7 +326,8 @@ MicRichTextComposer >> textWithImage: anImage usingAnchor: anchor [
 		using images as links. Adding it even if the image is not a link causes no
 		harm (it is invisible), and this is the easiest place to add it."
 	"See https://en.wikipedia.org/wiki/Zero-width_space"
-	^ text, "16rFEFF asCharacter asString" ' ' asText
+	"16rFEFF asCharacter asString asText"
+	^ ' ' asText , text, ' ' asText
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
It was a known issue which surfaced in a new way.
There will now ne rendered a space before and after an image when rendered asText.