### PR TITLE
Adding a newLine before  the table

### DIFF
--- a/src/Microdown-LaTeXExporter/MicLaTeXWriter.class.st
+++ b/src/Microdown-LaTeXExporter/MicLaTeXWriter.class.st
@@ -302,6 +302,7 @@ MicLaTeXWriter >> visitStrike: aStrike [
 { #category : #'blocks - table' }
 MicLaTeXWriter >> visitTable: aTable [
 	| environment |
+	canvas newLine.
 	environment := canvas environment name: self tabularEnvironment.
 	aTable rows size = 0
 		ifTrue: [ environment with: [  ].


### PR DESCRIPTION
because they was put next to the text before then they are convert from Microdown to LaTeX.