### PR TITLE
Adding a newLine before each table when converted from Microdown to LaTeX

### DIFF
--- a/src/Microdown-LaTeXExporter-Tests/MicLaTeXWriterTest.class.st
+++ b/src/Microdown-LaTeXExporter-Tests/MicLaTeXWriterTest.class.st
@@ -429,7 +429,8 @@ MicLaTeXWriterTest >> testStrike [
 { #category : #tests }
 MicLaTeXWriterTest >> testTable [
 	self writeFor: factory tableSample.
-	self assert: writer contents equals: '\begin{tabular}{ll}', newLine ,
+	self assert: writer contents equals: newLine,
+													'\begin{tabular}{ll}', newLine ,
 													'\toprule', newLine ,
 													'\textbf{aaab} & \textbf{jkhjh} \\', newLine ,
 													'\midrule', newLine ,
@@ -442,7 +443,8 @@ MicLaTeXWriterTest >> testTable [
 MicLaTeXWriterTest >> testTableWhithoutHeader [
 	
 	self writeFor: (factory simpleTableWithoutHeaderTable).
-	self assert: writer contents equals: '\begin{tabular}{ll}', newLine ,
+	self assert: writer contents equals: newLine,
+													'\begin{tabular}{ll}', newLine ,
 													'\toprule', newLine ,
 													'aaab & jkhjh \\', newLine ,
 													'bar & rab \\', newLine ,

--- a/src/Microdown-LaTeXExporter-Tests/MicSBALaTeXWriterTest.class.st
+++ b/src/Microdown-LaTeXExporter-Tests/MicSBALaTeXWriterTest.class.st
@@ -131,7 +131,8 @@ MicSBALaTeXWriterTest >> testSimpleFloatingNoLanguage [
 { #category : #tests }
 MicSBALaTeXWriterTest >> testTable [
 	self writeFor: factory tableSample.
-	self assert: writer contents equals: '\begin{fullwidthtabular}{ll}', newLine ,
+	self assert: writer contents equals: newLine,
+'\begin{fullwidthtabular}{ll}', newLine ,
 '\toprule', newLine ,
 '\textbf{aaab} & \textbf{jkhjh} \\', newLine ,
 '\midrule', newLine ,
@@ -144,7 +145,8 @@ MicSBALaTeXWriterTest >> testTable [
 MicSBALaTeXWriterTest >> testTableWhithoutHeader [
 	
 	self writeFor: (factory simpleTableWithoutHeaderTable).
-	self assert: writer contents equals: '\begin{fullwidthtabular}{ll}', newLine ,
+	self assert: writer contents equals: newLine,
+'\begin{fullwidthtabular}{ll}', newLine ,
 '\toprule', newLine ,
 'aaab & jkhjh \\', newLine ,
 'bar & rab \\', newLine ,

--- a/src/Microdown-LaTeXExporter/MicLaTeXWriter.class.st
+++ b/src/Microdown-LaTeXExporter/MicLaTeXWriter.class.st
@@ -302,6 +302,7 @@ MicLaTeXWriter >> visitStrike: aStrike [
 { #category : #'blocks - table' }
 MicLaTeXWriter >> visitTable: aTable [
 	| environment |
+	canvas newLine.
 	environment := canvas environment name: self tabularEnvironment.
 	aTable rows size = 0
 		ifTrue: [ environment with: [  ].


### PR DESCRIPTION
While converting books from Pillar to Microdown, I also checked that we get the same result with the Microdown file than the Pillar file. But there was a problem with the table which was put next to the text before them. So I added a newLine in order to get the good result when we get the LaTeX file to pdf.