### PR TITLE
FIxes 543 nice environment

### DIFF
--- a/src/Microdown-HTMLExporter-Tests/MicHTMLVisitorTest.class.st
+++ b/src/Microdown-HTMLExporter-Tests/MicHTMLVisitorTest.class.st
@@ -38,7 +38,7 @@ MicHTMLVisitorTest >> generateFilesystemExample [
 Pharo is cool
 
 ```
-	this is a code blu blu
+this is a code blu blu
 ```
 ' ].
 	file := fileSystem workingDirectory / 'anExample2.md'.
@@ -47,7 +47,7 @@ Pharo is cool
 Pharo is **cool**
 
 ```
-	this is a code 2
+this is a code 2
 ```
 ' ]
 ]
@@ -96,7 +96,7 @@ MicHTMLVisitorTest >> testConvertMicFile [
 		assert: (fileSystem / 'anExample1.html') asFileReference contents
 		equals: newLine , '<h1>Foo</h1><a id="sec1"></a>' , newLine
 			, '<p>Pharo is cool</p>' , newLine
-			, '<pre><code>	this is a code blu blu</code></pre>' , newLine
+			, '<pre><code>this is a code blu blu</code></pre>' , newLine
 ]
 
 { #category : #tests }

--- a/src/Microdown-PrettyPrinter-Tests/MicTextualMicrodownExporterTest.class.st
+++ b/src/Microdown-PrettyPrinter-Tests/MicTextualMicrodownExporterTest.class.st
@@ -88,11 +88,11 @@ MicTextualMicrodownExporterTest >> testCodeBlockNewLine [
 
 	| mic |
 	mic := parser parse: '```
-	this is a codeblock
+this is a codeblock
 ```'.
 	self assert: (mic accept: visitor) contents equals: '
 ```
-	this is a codeblock
+this is a codeblock
 ```
 '
 ]

--- a/src/Microdown-Tests/MicCodeBlockTest.class.st
+++ b/src/Microdown-Tests/MicCodeBlockTest.class.st
@@ -190,8 +190,8 @@ MicCodeBlockTest >> testFourBackQuotesOnMultipleLinesWithText [
 	| codeBlock |
 	codeBlock := parser parse: '
 Before	
-	
-	
+
+
 ````pharo
 something in the way
 pif
@@ -211,7 +211,7 @@ MicCodeBlockTest >> testFourBackQuotesWithTextAround [
 	| codeBlock |
 	codeBlock := parser parse: '
 Start text here
-	
+
 ```` 
 something in the way
 ````

--- a/src/Microdown-Tests/MicEnvironmentBlockTest.class.st
+++ b/src/Microdown-Tests/MicEnvironmentBlockTest.class.st
@@ -341,7 +341,7 @@ MicEnvironmentBlockTest >> testInputFileOnOneLineWithSpaceBeforeJunkAfter [
 MicEnvironmentBlockTest >> testParagraphEnvironmentParagraph [
 	| root |
 	root := parser parse: 'What a super day for a ride.
-	
+
 <!card
 Sunn Special S3
 

--- a/src/Microdown-Tests/MicrodownParserTest.class.st
+++ b/src/Microdown-Tests/MicrodownParserTest.class.st
@@ -298,6 +298,32 @@ this is the end.'.
 	
 ]
 
+{ #category : #tests }
+MicrodownParserTest >> testHandlePrefixTabs [
+	| source tree columns column codeBlock |
+	source := '
+<!columns
+	<!column
+		```
+		foo := 2 + 3
+			ifHuge: [ "Well, it is not" ]
+		```
+		- List 
+		- Line 2
+	!>
+!>'.
+	tree := self parser parse: source.
+	columns := tree children first.
+	column := columns children first.
+	codeBlock := column children first.
+	self assert: columns class equals: MicColumnsBlock.
+	self assert: column class equals: MicColumnBlock.
+	self assert: codeBlock class equals: MicCodeBlock.
+	self assert: column children second class equals: MicUnorderedListBlock.
+	self assert: codeBlock body lines first equals: 'foo := 2 + 3'.
+	self assert: codeBlock body lines second equals: (String tab, 'ifHuge: [ "Well, it is not" ]').
+]
+
 { #category : #'tests - header' }
 MicrodownParserTest >> testHeaderLevel4 [
 	| source root |

--- a/src/Microdown/MicCodeBlock.class.st
+++ b/src/Microdown/MicCodeBlock.class.st
@@ -51,6 +51,19 @@ MicCodeBlock >> accept: aVisitor [
  	^ aVisitor visitCode: self
 ]
 
+{ #category : #public }
+MicCodeBlock >> closeMe [
+	"adjust prefix tabs based on first line
+	I am allowing the codeblock itself to be indented in the input, see motivation in Microdown issue: 543"
+	| codeLines tabs |
+	super closeMe.
+	codeLines := self code lines.
+	codeLines ifEmpty: [ ^ self ].
+	tabs := codeLines first size - codeLines first withoutPreTabs size.
+	self body: ((codeLines collect: [:line | line allButFirst: tabs]) joinUsing: String cr)
+	
+]
+
 { #category : #accessing }
 MicCodeBlock >> code [
 	^ self body

--- a/src/Microdown/MicEnvironmentBlock.class.st
+++ b/src/Microdown/MicEnvironmentBlock.class.st
@@ -98,15 +98,16 @@ MicEnvironmentBlock >> addLineAndReturnNextNode: line [
 	"add line to this node. 
 	Notice, the action is allowed to create new nodes in the block tree.
 	Returns the node to handle next line - typically self."
-	
+	| withoutPreTabs |
 	isClosed
 		ifTrue: [ ^ self ].
-	(self doesLineStartWithStopMarkup: line)
+	withoutPreTabs := line withoutPreTabs.
+	(self doesLineStartWithStopMarkup: withoutPreTabs)
 		ifTrue: [ ^ self ].
 	firstLine
 		ifNil:
-			[ firstLine := self extractFirstLineFrom: line ]
-		ifNotNil: [ ^ self bodyFromLine: line ].
+			[ firstLine := self extractFirstLineFrom: withoutPreTabs ]
+		ifNotNil: [ ^ self bodyFromLine: withoutPreTabs ].
 	^ self
 ]
 

--- a/src/Microdown/MicrodownParser.class.st
+++ b/src/Microdown/MicrodownParser.class.st
@@ -231,7 +231,7 @@ MicrodownParser >> handleLine: line [
 		-if the current block can consume the line, it manages it and this potentially creates a new block that becomes the current one.
 		When the line is not consumed, the current block is closed and its parent becomes the current one and the process is called back to treat the line."
 
-	(current canConsumeLine: line)
+	(current canConsumeLine: (line withoutPreTabs))
 		ifTrue: [ 
 			current := current addLineAndReturnNextNode: line.
 			^ current ]

--- a/src/Microdown/String.extension.st
+++ b/src/Microdown/String.extension.st
@@ -9,3 +9,9 @@ String >> asMicResourceReference [
 String >> resolveDocument: document [
 	^ self asMicResourceReference resolveDocument: document.
 ]
+
+{ #category : #'*Microdown' }
+String >> withoutPreTabs [
+	"return a copy of me, without tabs in the begining "
+	^ self trimLeft: [ :char | char = Character tab ]
+]


### PR DESCRIPTION
Made a test similar to original proposal.
Implemented as suggested in the issue.
Fixed a number of tests that depended on near empty lines with just a single tab in the line.