### PR TITLE
Add buildMicrodown as Ring extension methods needed for browsing a remote repository from Calypso

### DIFF
--- a/src/Microdown/RGBehavior.extension.st
+++ b/src/Microdown/RGBehavior.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #RGBehavior }
+
+{ #category : #'*Microdown' }
+RGBehavior >> buildMicroDownUsing: aMicMicrodownTextualBuilder withComment: aString [
+
+	aMicMicrodownTextualBuilder
+		header: [ aMicMicrodownTextualBuilder text: 'Class: '.
+					aMicMicrodownTextualBuilder text: self name ] withLevel: 1;
+		horizontalLine;
+		text: aString
+]

--- a/src/Microdown/RGPackage.extension.st
+++ b/src/Microdown/RGPackage.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #RGPackage }
+
+{ #category : #'*Microdown' }
+RGPackage >> buildMicroDownUsing: aMicMicrodownTextualBuilder withComment: aString [
+
+	aMicMicrodownTextualBuilder
+		header: [ aMicMicrodownTextualBuilder text: 'Class: '.
+					aMicMicrodownTextualBuilder text: self name ] withLevel: 1;
+		horizontalLine;
+		text: aString
+]


### PR DESCRIPTION
Add buildMicrodownUsing:withComment: as extension methods in Ring. See https://github.com/pharo-project/pharo/pull/12425#pullrequestreview-1272249086 for details.
