### PR TITLE
Remove deprecated call

### DIFF
--- a/.github/workflows/tests-all.yml
+++ b/.github/workflows/tests-all.yml
@@ -19,11 +19,11 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        smalltalk: [ Pharo64-11 ]
+        smalltalk: [ Pharo64-12 ]
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.smalltalk }} on ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup smalltalkCI
         uses: hpi-swa/setup-smalltalkCI@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: hpi-swa/setup-smalltalkCI@v1
         id: smalltalkci
         with:
-          smalltalk-image: Pharo64-11
+          smalltalk-image: Pharo64-12
       - run: smalltalkci -s ${{ steps.smalltalkci.outputs.smalltalk-image }}
         shell: bash
         timeout-minutes: 15

--- a/src/Microdown-Tests/MicMicrodownSnippetFactory.class.st
+++ b/src/Microdown-Tests/MicMicrodownSnippetFactory.class.st
@@ -38,7 +38,7 @@ MicMicrodownSnippetFactory class >> buildDocument [
 	^ String streamContents: [ : stream | 
 		| factory |
 		factory := self new.
-		(self protocols difference: { #initialization . #utilities })
+		(self protocolNames difference: { #initialization . #utilities })
 			collect: [ : protoName | self organization listAtCategoryNamed: protoName ]
 			thenDo: [ : protoCollection |
 				protoCollection 


### PR DESCRIPTION
In Pharo 12 we should use #protocolNames instead of #protocols if we want the protocol names. 

#protocols will be updated to return real protocols and not names.