### PR TITLE
Update usage of Shout

### DIFF
--- a/src/Microdown-RichTextComposer/MicSmalltalkTextStyler.class.st
+++ b/src/Microdown-RichTextComposer/MicSmalltalkTextStyler.class.st
@@ -8,26 +8,14 @@ Class {
 	#category : #'Microdown-RichTextComposer-Composer'
 }
 
-{ #category : #attributes }
-MicSmalltalkTextStyler class >> initialTextAttributesForPixelHeight: aNumber [
-	"Render undefined same way as defined"
-
-	"Perhaps this is not the right spot to hook into stuff, but it seems to work"
-
-	| dict |
-	dict := super initialTextAttributesForPixelHeight: aNumber.
-	dict at: #undefinedIdentifier put: (dict at: #instVar).
-	dict at: #undefinedSelector put: (dict at: #patternSelector).
-	^ dict
-]
-
 { #category : #'class initialization' }
 MicSmalltalkTextStyler class >> initialize [
 	"I have my own set of class side variables. I should not, but alas, so it is"
+
 	"do not super initialize, that whould interfer with settings"
+
 	styleTable := SHRBTextStyler styleTable. "Not super, as that would just refer to my class-side variables"
-	formatIncompleteIdentifiers := false.
-	textAttributesByPixelHeight := nil.
+	formatIncompleteIdentifiers := false
 ]
 
 { #category : #'instance creation' }
@@ -36,6 +24,16 @@ MicSmalltalkTextStyler class >> new [
 	self styleTable = SHRBTextStyler styleTable "style table was changed"
 		ifFalse: [ self initialize ]. 
 	^ super new 
+]
+
+{ #category : #private }
+MicSmalltalkTextStyler >> attributesFor: aSymbol [
+
+	| symbol |
+	symbol := aSymbol.
+	symbol = #undefinedIdentifier ifTrue: [ symbol := #instVar ].
+	symbol = #undefinedSelector ifTrue: [ symbol := #patternSelector ].
+	^ super attributesFor: symbol
 ]
 
 { #category : #private }

--- a/src/Microdown-RichTextComposer/MicSmalltalkTextStyler.class.st
+++ b/src/Microdown-RichTextComposer/MicSmalltalkTextStyler.class.st
@@ -31,6 +31,8 @@ MicSmalltalkTextStyler >> attributesFor: aSymbol [
 
 	| symbol |
 	symbol := aSymbol.
+	
+	"In microdown we do not want a special color for undefinied selectors and identifiers so we just ask the common color instead."
 	symbol = #undefinedIdentifier ifTrue: [ symbol := #instVar ].
 	symbol = #undefinedSelector ifTrue: [ symbol := #patternSelector ].
 	^ super attributesFor: symbol


### PR DESCRIPTION
Shout implements code to deal with fonts but this code is never used and probably do not work with Pharo's scaling and other features.  To simplify Shout this will probably be removed leading to the removal of #initialTextAttributesForPixelHeight:. 

Since Microdown is using this method, I propose an alternative way to update the behavior of Microdown styler to allow the refactor of Shout.