### PR TITLE
Remove a dead method

### DIFF
--- a/src/Microdown/MicAbstractBlock.class.st
+++ b/src/Microdown/MicAbstractBlock.class.st
@@ -100,11 +100,6 @@ MicAbstractBlock >> initialize [
 	children := OrderedCollection new.
 ]
 
-{ #category : #'*Microdown-DocumentBrowser' }
-MicAbstractBlock >> isRootSection [ 
-	^ false
-]
-
 { #category : #testing }
 MicAbstractBlock >> listItemBlockClass [
 	^ MicListItemBlock

--- a/src/Microdown/MicAbstractBlock.extension.st
+++ b/src/Microdown/MicAbstractBlock.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #MicAbstractBlock }
-
-{ #category : #'*Microdown-DocumentBrowser' }
-MicAbstractBlock >> isRootSection [ 
-	^ false
-]


### PR DESCRIPTION
This method was for an older version of the document browser and is not needed anymore