### PR TITLE
Trivial cleanup: Duplicated methods and category

### DIFF
--- a/src/Microdown-Tests/MicFormatBlockTest.class.st
+++ b/src/Microdown-Tests/MicFormatBlockTest.class.st
@@ -200,22 +200,3 @@ MicFormatBlockTest >> testPrintingItalic [
 	bold := (self parser parse: '_a b_') children first children first.
 	self assert: bold printString equals: 'ItalicFormat(Text(a b))'
 ]
-
-{ #category : 'tests' }
-MicFormatBlockTest >> testProperties [
-
-	self assert: self subject properties isNotNil.
-	self subject instVarNamed: 'properties' put: nil.
-
-	self subject propertyAt: #foo put: #bar.
-	self subject instVarNamed: 'properties' put: nil.
-
-	self subject propertyAt: #foo ifAbsent: [ nil ].
-	self subject instVarNamed: 'properties' put: nil.
-
-	self subject propertyAt: #foo ifAbsentPut: [ #bar ].
-	self subject instVarNamed: 'properties' put: nil.
-
-	self subject hasProperty: #foo.
-	self subject instVarNamed: 'properties' put: nil
-]

--- a/src/Microdown/MicAnnotationBlock.class.st
+++ b/src/Microdown/MicAnnotationBlock.class.st
@@ -90,12 +90,6 @@ MicAnnotationBlock >> arguments: anArguments [
 	arguments := anArguments
 ]
 
-{ #category : 'visiting' }
-MicAnnotationBlock >> closeMe [ 
-
-	
-]
-
 { #category : 'accessing' }
 MicAnnotationBlock >> closingDelimiter [
 

--- a/src/Microdown/MicMathBlock.class.st
+++ b/src/Microdown/MicMathBlock.class.st
@@ -32,12 +32,6 @@ MicMathBlock >> accept: aVisitor [
  	^ aVisitor visitMath: self
 ]
 
-{ #category : 'accessing' }
-MicMathBlock >> arguments [
-
-	^ arguments
-]
-
 { #category : 'handle' }
 MicMathBlock >> extractFirstLineFrom: aLine [
 

--- a/src/Microdown/MicSameStartStopMarkupBlock.class.st
+++ b/src/Microdown/MicSameStartStopMarkupBlock.class.st
@@ -34,7 +34,7 @@ MicSameStartStopMarkupBlock >> caption [
 	^ String streamContents: [:s |  self captionElements do: [ :each | s nextPutAll: each substring ] ]
 ]
 
-{ #category : 'accessing-delegated' }
+{ #category : 'accessing - delegated' }
 MicSameStartStopMarkupBlock >> caption: aString [
 	
 	arguments at: #caption put: (MicInlineParser new parse: aString)


### PR DESCRIPTION
- fixes https://github.com/pharo-project/pharo/issues/11061
- remove some duplicated methods from the hierarchy