### PR TITLE
Add missing method to render package comments

### DIFF
--- a/src/Microdown/BaselineOf.extension.st
+++ b/src/Microdown/BaselineOf.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #BaselineOf }
+Extension { #name : 'BaselineOf' }
 
-{ #category : #'*Microdown' }
+{ #category : '*Microdown' }
 BaselineOf class >> buildMicroDownUsing: aBuilder withComment: aString [
 	aBuilder
 		header: [ aBuilder text: self name ] withLevel: 1;

--- a/src/Microdown/Class.extension.st
+++ b/src/Microdown/Class.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Class }
+Extension { #name : 'Class' }
 
-{ #category : #'*Microdown' }
+{ #category : '*Microdown' }
 Class >> addDocumentSectionExampleCodeTo: aBuilder [
 
 	| exampleCode |
@@ -13,7 +13,7 @@ Class >> addDocumentSectionExampleCodeTo: aBuilder [
 	aBuilder codeblock: exampleCode
 ]
 
-{ #category : #'*Microdown' }
+{ #category : '*Microdown' }
 Class >> addDocumentSectionTo: aBuilder label: label methods: methods [
 	
 	methods ifEmpty: [ ^ self ].
@@ -26,7 +26,7 @@ Class >> addDocumentSectionTo: aBuilder label: label methods: methods [
 				aBuilder monospace: (each methodClass name, '>>#', each selector) ] ] ]
 ]
 
-{ #category : #'*Microdown' }
+{ #category : '*Microdown' }
 Class >> buildMicroDownUsing: aBuilder withComment: aString [
 	
 	aBuilder 
@@ -43,7 +43,7 @@ Class >> buildMicroDownUsing: aBuilder withComment: aString [
 		methods: (self class methods select: [ :each | each protocol = self documentExamplesProtocol ])
 ]
 
-{ #category : #'*Microdown' }
+{ #category : '*Microdown' }
 Class >> documentExampleCode [
 	| exampleMethod |
 	
@@ -60,13 +60,13 @@ Class >> documentExampleCode [
 		trimmed
 ]
 
-{ #category : #'*Microdown' }
+{ #category : '*Microdown' }
 Class >> documentExampleCodeSelector [
 	
 	^ 'example*'
 ]
 
-{ #category : #'*Microdown' }
+{ #category : '*Microdown' }
 Class >> documentExamplesProtocol [
 	
 	^ #'*Examples'

--- a/src/Microdown/FileReference.extension.st
+++ b/src/Microdown/FileReference.extension.st
@@ -1,11 +1,11 @@
-Extension { #name : #FileReference }
+Extension { #name : 'FileReference' }
 
-{ #category : #'*Microdown' }
+{ #category : '*Microdown' }
 FileReference >> asMicResourceReference [ 
 	^ MicFileResourceReference fromFileRef: self
 ]
 
-{ #category : #'*Microdown' }
+{ #category : '*Microdown' }
 FileReference >> resolveDocument: document [
 	^ self asMicResourceReference resolveDocument: document.
 ]

--- a/src/Microdown/ManifestMicrodown.class.st
+++ b/src/Microdown/ManifestMicrodown.class.st
@@ -64,17 +64,19 @@ Such packages should be moved in the future to other location (probably pillar i
 I was implemented by S. Ducasse, L. Dargaud and G. Polito. It is based on the work on markdown parsing of K. Osterbye. 
 "
 Class {
-	#name : #ManifestMicrodown,
-	#superclass : #PackageManifest,
-	#category : #'Microdown-Manifest'
+	#name : 'ManifestMicrodown',
+	#superclass : 'PackageManifest',
+	#category : 'Microdown-Manifest',
+	#package : 'Microdown',
+	#tag : 'Manifest'
 }
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestMicrodown class >> ruleAnySatisfyRuleV1FalsePositive [
 	^ #(#(#(#RGMethodDefinition #(#'MicFileResourceReference class' #hostOf: #true)) #'2022-01-15T12:11:48.574879+01:00') )
 ]
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestMicrodown class >> ruleUtilityMethodsRuleV1FalsePositive [
 	^ #(#(#(#RGMethodDefinition #(#MicElement #resolveFrom: #false)) #'2022-04-27T08:53:19.440198+02:00') )
 ]

--- a/src/Microdown/MicAbsoluteResourceReference.class.st
+++ b/src/Microdown/MicAbsoluteResourceReference.class.st
@@ -5,56 +5,58 @@ A reference will then be resolved and produces a resource.
 Common for all absolute references is that they store their reference in a uri (ZnUrl).
 "
 Class {
-	#name : #MicAbsoluteResourceReference,
-	#superclass : #MicResourceReference,
+	#name : 'MicAbsoluteResourceReference',
+	#superclass : 'MicResourceReference',
 	#instVars : [
 		'uri'
 	],
-	#category : #'Microdown-Core'
+	#category : 'Microdown-Core',
+	#package : 'Microdown',
+	#tag : 'Core'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAbsoluteResourceReference >> binaryReadStream [
 	"return the binaryStream I refer to"
 	self subclassResponsibility.
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicAbsoluteResourceReference >> canSave [
 	"return true if I implement contents: "
 	^ false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAbsoluteResourceReference >> contents [
 	"return the contents I refer to"
 	self subclassResponsibility.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAbsoluteResourceReference >> contents: aString [
 	"Some of my subclasses can be written to. By default you cannot, and I then give an error"
 	MicResourceReferenceError signal: self printString, ' can not be given new contents'
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicAbsoluteResourceReference >> isMicrodownResourceFileReference [
 	^ false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAbsoluteResourceReference >> loadChildren [
 	"return a collection of absolute child references"
 	^#()
 ]
 
-{ #category : #loading }
+{ #category : 'loading' }
 MicAbsoluteResourceReference >> loadImage [
 	"Throws UnrecognizedImageFormatError in case Pharo does not understand this image type (for exampel svg is not supported)"
 	^ ImageReadWriter formFromStream: self binaryReadStream
 ]
 
-{ #category : #loading }
+{ #category : 'loading' }
 MicAbsoluteResourceReference >> loadMicrodown [
 	"I am an absolute reference, so I can load completely"
 	| doc| 
@@ -63,13 +65,13 @@ MicAbsoluteResourceReference >> loadMicrodown [
 	^ doc
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAbsoluteResourceReference >> path [
 	"return the path part of my uri"
 	^ '/', uri path
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MicAbsoluteResourceReference >> printOn: aStream [
 	super printOn: aStream.
 	aStream
@@ -78,7 +80,7 @@ MicAbsoluteResourceReference >> printOn: aStream [
 		nextPutAll: ')'
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicAbsoluteResourceReference >> resolveDocument: document [
 	MicZincPathResolver 
 		resolve: document 
@@ -86,18 +88,18 @@ MicAbsoluteResourceReference >> resolveDocument: document [
 	^ document
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAbsoluteResourceReference >> uri [
 
 	^ uri
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAbsoluteResourceReference >> uri: aZnUrl [
 	uri := aZnUrl
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAbsoluteResourceReference >> uriString [
 	^ uri printString
 ]

--- a/src/Microdown/MicAbstractAnnotatedBlock.class.st
+++ b/src/Microdown/MicAbstractAnnotatedBlock.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #MicAbstractAnnotatedBlock,
-	#superclass : #MicAbstractBlock,
+	#name : 'MicAbstractAnnotatedBlock',
+	#superclass : 'MicAbstractBlock',
 	#instVars : [
 		'label',
 		'isClosed',
 		'body'
 	],
-	#category : #'Microdown-Model'
+	#category : 'Microdown-Model',
+	#package : 'Microdown',
+	#tag : 'Model'
 }
 
-{ #category : #public }
+{ #category : 'public' }
 MicAbstractAnnotatedBlock >> addLineAndReturnNextNode: line [
 	"line is assumed to be of the form '!!label some text'"
 
@@ -26,12 +28,12 @@ MicAbstractAnnotatedBlock >> addLineAndReturnNextNode: line [
 		ifNotNil: [ body := body , String cr , line ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAbstractAnnotatedBlock >> body [
 	^ body
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicAbstractAnnotatedBlock >> canConsumeLine: line [
 	"return if this block can consume line"
 
@@ -39,19 +41,19 @@ MicAbstractAnnotatedBlock >> canConsumeLine: line [
 	^ line isNotEmpty 
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MicAbstractAnnotatedBlock >> initialize [
 
 	super initialize.
 	isClosed := false.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAbstractAnnotatedBlock >> label [
 	^ label
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicAbstractAnnotatedBlock >> lineMarkup [
 
 	^ self subclassResponsibility

--- a/src/Microdown/MicAbstractBlock.class.st
+++ b/src/Microdown/MicAbstractBlock.class.st
@@ -7,28 +7,30 @@ I have a set of children, and an uplink to my parent.
 See the comment of `MicroDownParser` for an overview of the algorithm used in building such parse tree.
 "
 Class {
-	#name : #MicAbstractBlock,
-	#superclass : #MicElement,
+	#name : 'MicAbstractBlock',
+	#superclass : 'MicElement',
 	#instVars : [
 		'children',
 		'parser'
 	],
-	#category : #'Microdown-Model'
+	#category : 'Microdown-Model',
+	#package : 'Microdown',
+	#tag : 'Model'
 }
 
-{ #category : #public }
+{ #category : 'public' }
 MicAbstractBlock class >> alternateBlockClassFor: line [
 	"This hook supports extensions of environments. 
 	we get <?slide ... and we do not create an environment but a slideBlock"
 	^ self
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 MicAbstractBlock >> addChild: childBlock [
 	children add: childBlock
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 MicAbstractBlock >> addLineAndReturnNextNode: line [
 	"add line to this node. 
 	Notice, the action is allowed to create new nodes in the block tree.
@@ -38,81 +40,81 @@ MicAbstractBlock >> addLineAndReturnNextNode: line [
 	^ self
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 MicAbstractBlock >> blockExtensionStarterClassFrom: line [
 	"return the class of a block which can start with line, or nil if none"
 
 	^ nil
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 MicAbstractBlock >> blockStarterClassFrom: line [
 	"return the class of a block which can start with line, or nil if none"
 
 	^ (self parser blockStarterClassFrom: line) ifNotNil: [ :c | c alternateBlockClassFor: line ]
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 MicAbstractBlock >> canConsumeLine: line [
 	"return if this block can consume line"
 
 	^ self subclassResponsibility 
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 MicAbstractBlock >> children [
 	^children 
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 MicAbstractBlock >> children: aCollection [
  	children := aCollection
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 MicAbstractBlock >> closeMe [
 	"I'm hook for closing elements. By default do nothing."
 	
 	^ self
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 MicAbstractBlock >> computeNestedLevel [ 
 
 	^ 0
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 MicAbstractBlock >> hasProperty: aKey [
 	"Test if the property aKey is present."
 	
 	^ self properties notNil and: [ self properties includesKey: aKey ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAbstractBlock >> indent [
 	^ parent indent
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MicAbstractBlock >> initialize [
 	super initialize. 
 	children := OrderedCollection new.
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicAbstractBlock >> listItemBlockClass [
 	^ MicListItemBlock
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 MicAbstractBlock >> nestedLevel [ 
 	"Return the nesting level of main blocks. Basically only list increases this."
 	
 	^ 0
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 MicAbstractBlock >> newBlockFor: line parent: parentBlock [
 	| newBlockClass |
 	newBlockClass := self blockStarterClassFrom: line.
@@ -123,44 +125,44 @@ MicAbstractBlock >> newBlockFor: line parent: parentBlock [
 		addLineAndReturnNextNode: line
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MicAbstractBlock >> parser [
 	^ parser 
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MicAbstractBlock >> parserClass [ 
 	^ MicrodownParser
 ]
 
-{ #category : #replacement }
+{ #category : 'replacement' }
 MicAbstractBlock >> replace: aBlock by: anotherBlock [ 
 	
 	children replaceAll: aBlock with: anotherBlock 
 ]
 
-{ #category : #replacement }
+{ #category : 'replacement' }
 MicAbstractBlock >> replace: aBlock byCollection: aCollection [ 
 	
 	children := children copyReplaceAll: {aBlock} with: aCollection 
 ]
 
-{ #category : #replacement }
+{ #category : 'replacement' }
 MicAbstractBlock >> replaceBy: anotherBlock [ 
 	self parent replace: self by: anotherBlock
 ]
 
-{ #category : #replacement }
+{ #category : 'replacement' }
 MicAbstractBlock >> replaceByAll: aCollection [ 
 	self parent replace: self byCollection: aCollection 
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MicAbstractBlock >> setParser: aParser [
 	parser := aParser 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAbstractBlock >> text [
 	| text |
 	self flag: #todo.

--- a/src/Microdown/MicAbstractCodeBlock.class.st
+++ b/src/Microdown/MicAbstractCodeBlock.class.st
@@ -2,12 +2,14 @@
 I am common class for two extension blocks which at the moment shares the same syntax.
 "
 Class {
-	#name : #MicAbstractCodeBlock,
-	#superclass : #MicSameStartStopMarkupBlock,
-	#category : #'Microdown-Model'
+	#name : 'MicAbstractCodeBlock',
+	#superclass : 'MicSameStartStopMarkupBlock',
+	#category : 'Microdown-Model',
+	#package : 'Microdown',
+	#tag : 'Model'
 }
 
-{ #category : #public }
+{ #category : 'public' }
 MicAbstractCodeBlock class >> alternateBlockClassFor: line [
 
 	"If there is one subclass with the corresponding tag, returns it, else resturn the current class."
@@ -20,17 +22,17 @@ MicAbstractCodeBlock class >> alternateBlockClassFor: line [
 	^ MicScriptBlock allSubclasses detect: [ :each | each tag = tag ] ifNone: [ MicCodeBlock ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAbstractCodeBlock class >> defaultLanguage [
 	^ 'Pharo'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAbstractCodeBlock >> language [
 	^ arguments at: #language
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MicAbstractCodeBlock >> lineStartMarkup [
 	"a code block is delimited by ``` "
 	

--- a/src/Microdown/MicAbstractMicrodownTextualBuilder.class.st
+++ b/src/Microdown/MicAbstractMicrodownTextualBuilder.class.st
@@ -3,8 +3,8 @@ I'm a copy of Pillar textual canvas. I should be fusioned in my subclass.
 We should revisit the API because parsing lines is a not really good design.
 "
 Class {
-	#name : #MicAbstractMicrodownTextualBuilder,
-	#superclass : #Object,
+	#name : 'MicAbstractMicrodownTextualBuilder',
+	#superclass : 'Object',
 	#instVars : [
 		'stream',
 		'lastIsNewLine',
@@ -13,33 +13,35 @@ Class {
 	#pools : [
 		'MicMicrodownSharedPool'
 	],
-	#category : #'Microdown-Parser'
+	#category : 'Microdown-Parser',
+	#package : 'Microdown',
+	#tag : 'Parser'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MicAbstractMicrodownTextualBuilder class >> on: aStream [ 
 	^ self new
 		setStream: aStream;
 		yourself
 ]
 
-{ #category : #formatting }
+{ #category : 'formatting' }
 MicAbstractMicrodownTextualBuilder >> bold: aText [
 
 	self writeText: aText surroundBy: BoldMarkup
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAbstractMicrodownTextualBuilder >> contents [
 	^ stream contents
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MicAbstractMicrodownTextualBuilder >> flush [
 	stream flush
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MicAbstractMicrodownTextualBuilder >> initialize [
 	super initialize.
 	stream := (String new: 1000) writeStream.
@@ -47,86 +49,86 @@ MicAbstractMicrodownTextualBuilder >> initialize [
 	lastIsNewLine := true
 ]
 
-{ #category : #formatting }
+{ #category : 'formatting' }
 MicAbstractMicrodownTextualBuilder >> italic: aText [
 
 	self writeText: aText surroundBy: ItalicMarkup
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicAbstractMicrodownTextualBuilder >> lastIsNewLine [
 	^ lastIsNewLine
 ]
 
-{ #category : #'writing text' }
+{ #category : 'writing text' }
 MicAbstractMicrodownTextualBuilder >> line: aString [
 	self
 		nextPutAll: aString;
 		newLine
 ]
 
-{ #category : #formatting }
+{ #category : 'formatting' }
 MicAbstractMicrodownTextualBuilder >> monospace: aText [
 
 	self writeText: aText surroundBy: MonospaceMarkup
 ]
 
-{ #category : #'writing text' }
+{ #category : 'writing text' }
 MicAbstractMicrodownTextualBuilder >> newLine [
 	self raw: newLineCharacterString.
 	lastIsNewLine := true
 ]
 
-{ #category : #'writing text' }
+{ #category : 'writing text' }
 MicAbstractMicrodownTextualBuilder >> nextPut: aCharacter [
 	stream nextPut: aCharacter.
 	lastIsNewLine := false
 ]
 
-{ #category : #'writing text' }
+{ #category : 'writing text' }
 MicAbstractMicrodownTextualBuilder >> nextPutAll: aString [
 	
 	aString do: [ :char | self nextPut: char ]
 ]
 
-{ #category : #'writing low-level' }
+{ #category : 'writing low-level' }
 MicAbstractMicrodownTextualBuilder >> potentialNewLine [
 	lastIsNewLine ifFalse: [ self newLine ]
 ]
 
-{ #category : #'writing text' }
+{ #category : 'writing text' }
 MicAbstractMicrodownTextualBuilder >> raw: aString [
 	stream << aString
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MicAbstractMicrodownTextualBuilder >> setNewLineCharacterString: aLine [
 	newLineCharacterString := aLine
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MicAbstractMicrodownTextualBuilder >> setStream: aStream [ 
 	stream := aStream
 ]
 
-{ #category : #'writing text' }
+{ #category : 'writing text' }
 MicAbstractMicrodownTextualBuilder >> space [
 	stream space
 ]
 
-{ #category : #formatting }
+{ #category : 'formatting' }
 MicAbstractMicrodownTextualBuilder >> strike: aText [
 
 	self writeText: aText surroundBy: StrikeMarkup
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MicAbstractMicrodownTextualBuilder >> text: aText [
 	self raw: aText
 	
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MicAbstractMicrodownTextualBuilder >> writeDuring: aBlock surroundBy: anOpenerMarkup and: aCloserMarkup [
 
 	self raw: anOpenerMarkup.
@@ -134,7 +136,7 @@ MicAbstractMicrodownTextualBuilder >> writeDuring: aBlock surroundBy: anOpenerMa
 	self raw: aCloserMarkup
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MicAbstractMicrodownTextualBuilder >> writeLinkDuring: aBlockClosure destination: aString [ 
 	
 	self
@@ -143,7 +145,7 @@ MicAbstractMicrodownTextualBuilder >> writeLinkDuring: aBlockClosure destination
 		title: nil
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MicAbstractMicrodownTextualBuilder >> writeLinkDuring: aBlockClosure destination: aDestination title: aTitle [ 
 
 	self raw: '['.
@@ -162,13 +164,13 @@ MicAbstractMicrodownTextualBuilder >> writeLinkDuring: aBlockClosure destination
 	 ]
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MicAbstractMicrodownTextualBuilder >> writeNewLine [
 	self raw: String cr
 	
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MicAbstractMicrodownTextualBuilder >> writeText: aText beginsWith: aMarkup [
 	self
 		raw: aMarkup;
@@ -176,12 +178,12 @@ MicAbstractMicrodownTextualBuilder >> writeText: aText beginsWith: aMarkup [
 		raw: aText
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MicAbstractMicrodownTextualBuilder >> writeText: aText surroundBy: aMarkup [
 	self writeText: aText surroundBy: aMarkup and: aMarkup
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MicAbstractMicrodownTextualBuilder >> writeText: aText surroundBy: anOpenerMarkup and: aCloserMarkup [
 	self
 		raw: anOpenerMarkup;

--- a/src/Microdown/MicAnchorBlock.class.st
+++ b/src/Microdown/MicAnchorBlock.class.st
@@ -7,21 +7,23 @@ I'm block that represents an anchor to a section. This way text can refer to the
 ``` 
 "
 Class {
-	#name : #MicAnchorBlock,
-	#superclass : #MicSingleLineBlock,
+	#name : 'MicAnchorBlock',
+	#superclass : 'MicSingleLineBlock',
 	#instVars : [
 		'label',
 		'target'
 	],
-	#category : #'Microdown-Model'
+	#category : 'Microdown-Model',
+	#package : 'Microdown',
+	#tag : 'Model'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicAnchorBlock >> accept: aVisitor [
  	^ aVisitor visitAnchor: self
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 MicAnchorBlock >> addLineAndReturnNextNode: line [
 	"# bla
 	@myanchor
@@ -30,28 +32,28 @@ MicAnchorBlock >> addLineAndReturnNextNode: line [
 	^ self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicAnchorBlock >> hasLabel [ 
 	label ifNil: [ ^ false ].
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAnchorBlock >> label [
 	^ label
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAnchorBlock >> label: anObject [
 	label := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAnchorBlock >> target [
 	^ target
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAnchorBlock >> target: aMicHeaderBlock [ 
 	target := aMicHeaderBlock
 ]

--- a/src/Microdown/MicAnchorLinker.class.st
+++ b/src/Microdown/MicAnchorLinker.class.st
@@ -11,12 +11,14 @@ I'm usually invoked in a post parsing phase, so transparent to the user.
 
 "
 Class {
-	#name : #MicAnchorLinker,
-	#superclass : #MicrodownVisitor,
-	#category : #'Microdown-Visitor'
+	#name : 'MicAnchorLinker',
+	#superclass : 'MicrodownVisitor',
+	#category : 'Microdown-Visitor',
+	#package : 'Microdown',
+	#tag : 'Visitor'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicAnchorLinker >> visitHeader: aHeader [
 
 	| siblings position potentialAnchor | 

--- a/src/Microdown/MicAnchorReferenceBlock.class.st
+++ b/src/Microdown/MicAnchorReferenceBlock.class.st
@@ -7,38 +7,40 @@ See *@fig1@*
 
 "
 Class {
-	#name : #MicAnchorReferenceBlock,
-	#superclass : #MicUnEvaluatedBlock,
+	#name : 'MicAnchorReferenceBlock',
+	#superclass : 'MicUnEvaluatedBlock',
 	#instVars : [
 		'reference'
 	],
-	#category : #'Microdown-InlineParser'
+	#category : 'Microdown-InlineParser',
+	#package : 'Microdown',
+	#tag : 'InlineParser'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAnchorReferenceBlock class >> closingDelimiter [
 
  	^ AnchorReferenceCloserMarkup
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAnchorReferenceBlock class >> openingDelimiter [
 
  	^ AnchorReferenceOpenerMarkup
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicAnchorReferenceBlock >> accept: aVisitor [
  	^ aVisitor visitAnchorReference: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAnchorReferenceBlock >> reference [
 
 	^ reference
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAnchorReferenceBlock >> reference: anObject [
 
 	reference := anObject

--- a/src/Microdown/MicAnnotatedBlock.class.st
+++ b/src/Microdown/MicAnnotatedBlock.class.st
@@ -12,36 +12,38 @@ See [https://github.com/pillar-markup/MicroDown/issues/54](https://github.com/pi
 
 "
 Class {
-	#name : #MicAnnotatedBlock,
-	#superclass : #MicAbstractAnnotatedBlock,
-	#category : #'Microdown-Model'
+	#name : 'MicAnnotatedBlock',
+	#superclass : 'MicAbstractAnnotatedBlock',
+	#category : 'Microdown-Model',
+	#package : 'Microdown',
+	#tag : 'Model'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicAnnotatedBlock >> accept: aVisitor [
  	^ aVisitor visitAnnotated: self
 ]
 
-{ #category : #'parse support' }
+{ #category : 'parse support' }
 MicAnnotatedBlock >> closeMe [
 	super closeMe.
 	body := self inlineParse: body
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicAnnotatedBlock >> lineMarkup [
 	
 	^ AnnotatedParagraphMarkup
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAnnotatedBlock >> text [
 
 	^ String streamContents: [ :s | 
 		  self textElements do: [ :each | s nextPutAll: each bodystring ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAnnotatedBlock >> textElements [
 
 	^ self body

--- a/src/Microdown/MicAnnotationBlock.class.st
+++ b/src/Microdown/MicAnnotationBlock.class.st
@@ -12,27 +12,29 @@ MicroDownParser parse: '{!citation|name=Duca99a!}'
 ```
 "
 Class {
-	#name : #MicAnnotationBlock,
-	#superclass : #MicUnEvaluatedBlock,
+	#name : 'MicAnnotationBlock',
+	#superclass : 'MicUnEvaluatedBlock',
 	#instVars : [
 		'arguments'
 	],
-	#category : #'Microdown-InlineParser'
+	#category : 'Microdown-InlineParser',
+	#package : 'Microdown',
+	#tag : 'InlineParser'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAnnotationBlock class >> closingDelimiter [
 
  	^ AnnotationCloserMarkup
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAnnotationBlock class >> openingDelimiter [
 
  	^ AnnotationOpenerMarkup
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 MicAnnotationBlock class >> parse: delimiter stream: aTokenStream for: aParser [
 	| bodystring arguments tag extensionClass |
 	bodystring := delimiter undelimitedSubstring.
@@ -49,24 +51,24 @@ MicAnnotationBlock class >> parse: delimiter stream: aTokenStream for: aParser [
 		arguments: arguments
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicAnnotationBlock >> accept: aVisitor [
 	^ aVisitor visitAnnotation: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAnnotationBlock >> arguments [
 
 	^ arguments
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAnnotationBlock >> arguments: argumentList [
 
 	arguments := argumentList
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicAnnotationBlock >> name [
 	^ arguments defaultValue
 ]

--- a/src/Microdown/MicArgumentList.class.st
+++ b/src/Microdown/MicArgumentList.class.st
@@ -9,23 +9,25 @@ My syntax is of the following form:
 - `value|key=arg[&key=arg]*` defaultArg->value, and arguments.
 "
 Class {
-	#name : #MicArgumentList,
-	#superclass : #OrderedDictionary,
+	#name : 'MicArgumentList',
+	#superclass : 'OrderedDictionary',
 	#instVars : [
 		'defaultArg',
 		'initialValue'
 	],
-	#category : #'Microdown-Parser'
+	#category : 'Microdown-Parser',
+	#package : 'Microdown',
+	#tag : 'Parser'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MicArgumentList class >> split: aString [
 	^ self new 
 		from: aString; 
 		yourself 
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MicArgumentList class >> split: aString defaultArg: defArg [
 	^ self new
 		defaultArg: defArg;
@@ -33,7 +35,7 @@ MicArgumentList class >> split: aString defaultArg: defArg [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MicArgumentList class >> split: aString defaultArg: defArg defaultValue: defValue [
 	^ self new
 		defaultArg: defArg;
@@ -43,34 +45,34 @@ MicArgumentList class >> split: aString defaultArg: defArg defaultValue: defValu
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MicArgumentList class >> withStream: aStream [
 	^ self split: aStream contents.
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MicArgumentList class >> withString: aString [
 	^ self split: aString 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicArgumentList >> defaultArg [
 
 	^ defaultArg ifNil: [ defaultArg := #defaultArg ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicArgumentList >> defaultArg: anObject [
 
 	defaultArg := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicArgumentList >> defaultValue [
 	^ self at: defaultArg ifAbsent: [ initialValue  ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MicArgumentList >> from: fullString [
 	"I am the 'parser' of the argument splitter"
 	| barSplit |
@@ -84,33 +86,33 @@ MicArgumentList >> from: fullString [
 	
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicArgumentList >> hasNonDefaultArguments [
 	"has changed #defaultArg or has other keys"
 	^ self hasNonDefaultValue or: [ (self keys copyWithout: self defaultArg ) notEmpty  ]
 		
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicArgumentList >> hasNonDefaultValue [
 	"return true if the default arg was given a value"
 	^ self defaultValue notNil and: [ self defaultValue ~= initialValue  ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicArgumentList >> initialValue: anObject [
 
 	initialValue := anObject
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 MicArgumentList >> justTheArguments [
 	^ self copy 
 		removeKey: defaultArg ifAbsent: [ ]; 
 		yourself 
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MicArgumentList >> printOn: aStream [
 	|argKeys|
 	self hasNonDefaultValue 
@@ -122,12 +124,12 @@ MicArgumentList >> printOn: aStream [
 	aStream nextPutAll: ((argKeys collect: [:k| k,'=',(self at:k)]) joinUsing: '&')
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MicArgumentList >> printString [
 	^ String streamContents: [ :stream | self printOn: stream ]
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 MicArgumentList >> setDefaultAndArguments: barSplit [
 	"barSplit is two strings, first assumed to be just a value, second to be arguments"
 	|value|
@@ -136,7 +138,7 @@ MicArgumentList >> setDefaultAndArguments: barSplit [
 	self setNoDefaultButArguments: barSplit second
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 MicArgumentList >> setDefaultNoArguments: fullString [
 	"fullstring is just a name (containing no arguments)
 	It is interpreted as both a name, and as an argument with no value"
@@ -145,7 +147,7 @@ MicArgumentList >> setDefaultNoArguments: fullString [
 	self at: self defaultArg put: value
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 MicArgumentList >> setNoDefaultButArguments: string [
 	"string is assumed to be on the form key=value&key=value"
 	| pairs |
@@ -156,7 +158,7 @@ MicArgumentList >> setNoDefaultButArguments: string [
 	
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 MicArgumentList >> withoutDefaultValue [
 	"remove the defaultArg if no new value was assigned to it"
 	^ self hasNonDefaultValue 

--- a/src/Microdown/MicBoldFormatBlock.class.st
+++ b/src/Microdown/MicBoldFormatBlock.class.st
@@ -2,24 +2,26 @@
 I represent a bold text section. I'm delimited using `**` as in `**bold**` to obtain **bold**.
 "
 Class {
-	#name : #MicBoldFormatBlock,
-	#superclass : #MicEvaluatedBlock,
-	#category : #'Microdown-InlineParser'
+	#name : 'MicBoldFormatBlock',
+	#superclass : 'MicEvaluatedBlock',
+	#category : 'Microdown-InlineParser',
+	#package : 'Microdown',
+	#tag : 'InlineParser'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicBoldFormatBlock class >> closingDelimiter [
 
  	^ BoldMarkup
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicBoldFormatBlock class >> openingDelimiter [
 
  	^ BoldMarkup
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicBoldFormatBlock >> accept: aVisitor [
 	^ aVisitor visitBold: self
 ]

--- a/src/Microdown/MicCitationBlock.class.st
+++ b/src/Microdown/MicCitationBlock.class.st
@@ -8,23 +8,25 @@ this is a text with a {!citation|ref=Duca99a!}
 
 "
 Class {
-	#name : #MicCitationBlock,
-	#superclass : #MicAnnotationBlock,
-	#category : #'Microdown-Extensions'
+	#name : 'MicCitationBlock',
+	#superclass : 'MicAnnotationBlock',
+	#category : 'Microdown-Extensions',
+	#package : 'Microdown',
+	#tag : 'Extensions'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicCitationBlock class >> tag [
 
 	^ #citation
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicCitationBlock >> accept: aVisitor [
 	aVisitor visitCitation: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicCitationBlock >> ref [
 	^ arguments at: 'ref' ifAbsent: [ '' ]
 ]

--- a/src/Microdown/MicCodeBlock.class.st
+++ b/src/Microdown/MicCodeBlock.class.st
@@ -36,17 +36,19 @@ The current implementation stores lines in a single text and this is a bad idea 
 Second if we want to treat lines separatedly we have to reparse it. Now we do not need it so this is good but this is just by chance!
 "
 Class {
-	#name : #MicCodeBlock,
-	#superclass : #MicAbstractCodeBlock,
-	#category : #'Microdown-Model'
+	#name : 'MicCodeBlock',
+	#superclass : 'MicAbstractCodeBlock',
+	#category : 'Microdown-Model',
+	#package : 'Microdown',
+	#tag : 'Model'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicCodeBlock >> accept: aVisitor [
  	^ aVisitor visitCode: self
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 MicCodeBlock >> closeMe [
 	"adjust prefix tabs based on first line
 	I am allowing the codeblock itself to be indented in the input, see motivation in Microdown issue: 543"
@@ -59,12 +61,12 @@ MicCodeBlock >> closeMe [
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicCodeBlock >> code [
 	^ self body
 ]
 
-{ #category : #handle }
+{ #category : 'handle' }
 MicCodeBlock >> extractFirstLineFrom: aLine [
 	"language=Pharo&label=fig1&caption=La vie est belle"
 	"The first tag is language.
@@ -79,50 +81,50 @@ MicCodeBlock >> extractFirstLineFrom: aLine [
 	^ lineWithoutMarkup
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicCodeBlock >> hasBody [
 
 	^ body isNotEmpty
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicCodeBlock >> hasLabel [
 	^ arguments includesKey: #label
 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicCodeBlock >> hasNonDefaultArguments [
 
 	^ 	arguments hasNonDefaultArguments
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicCodeBlock >> hasNonDefaultLanguage [
 	"is the language defined explicitly"
 	^ arguments hasNonDefaultValue 
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MicCodeBlock >> initialize [
 	super initialize.
 	arguments := OrderedDictionary new.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicCodeBlock >> label [
 	"precondition: receiver hasLabel"
 	
 	^ arguments at: #label
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicCodeBlock >> label: aString [
 
 	self arguments at: #label put: aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicCodeBlock >> size [
 
 	"precondition: receiver hasLabel"

--- a/src/Microdown/MicColumnBlock.class.st
+++ b/src/Microdown/MicColumnBlock.class.st
@@ -12,27 +12,29 @@ I'm a bloc element that represents a column. I have one optional argument that i
 ```
 "
 Class {
-	#name : #MicColumnBlock,
-	#superclass : #MicEnvironmentBlock,
-	#category : #'Microdown-Extensions'
+	#name : 'MicColumnBlock',
+	#superclass : 'MicEnvironmentBlock',
+	#category : 'Microdown-Extensions',
+	#package : 'Microdown',
+	#tag : 'Extensions'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicColumnBlock class >> tag [
 	^ #column
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicColumnBlock >> accept: aVisitor [
 	^ aVisitor visitColumn: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicColumnBlock >> width [
 	^ arguments at: #width
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicColumnBlock >> width: anObject [
 	arguments at: #width put: anObject
 ]

--- a/src/Microdown/MicColumnsBlock.class.st
+++ b/src/Microdown/MicColumnsBlock.class.st
@@ -33,17 +33,19 @@ Note that a column can have also a width.
 ```
 "
 Class {
-	#name : #MicColumnsBlock,
-	#superclass : #MicEnvironmentBlock,
-	#category : #'Microdown-Extensions'
+	#name : 'MicColumnsBlock',
+	#superclass : 'MicEnvironmentBlock',
+	#category : 'Microdown-Extensions',
+	#package : 'Microdown',
+	#tag : 'Extensions'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicColumnsBlock class >> tag [
 	^ #columns
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicColumnsBlock >> accept: aVisitor [
 	^ aVisitor visitColumns: self
 ]

--- a/src/Microdown/MicCommentBlock.class.st
+++ b/src/Microdown/MicCommentBlock.class.st
@@ -6,17 +6,19 @@ Each line to be commented should start with %.
 I should be a subclass of SingleLineBlock and not continuousMarkedBlock.
 "
 Class {
-	#name : #MicCommentBlock,
-	#superclass : #MicContinuousMarkedBlock,
-	#category : #'Microdown-Model'
+	#name : 'MicCommentBlock',
+	#superclass : 'MicContinuousMarkedBlock',
+	#category : 'Microdown-Model',
+	#package : 'Microdown',
+	#tag : 'Model'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicCommentBlock >> accept: aVisitor [
  	^ aVisitor visitComment: self
 ]
 
-{ #category : #markups }
+{ #category : 'markups' }
 MicCommentBlock >> lineMarkup [
 
 	^ CommentedLineMarkup 

--- a/src/Microdown/MicContinuousMarkedBlock.class.st
+++ b/src/Microdown/MicContinuousMarkedBlock.class.st
@@ -30,15 +30,17 @@ produces
 
 "
 Class {
-	#name : #MicContinuousMarkedBlock,
-	#superclass : #MicAbstractBlock,
+	#name : 'MicContinuousMarkedBlock',
+	#superclass : 'MicAbstractBlock',
 	#instVars : [
 		'text'
 	],
-	#category : #'Microdown-Model'
+	#category : 'Microdown-Model',
+	#package : 'Microdown',
+	#tag : 'Model'
 }
 
-{ #category : #actions }
+{ #category : 'actions' }
 MicContinuousMarkedBlock >> addLineAndReturnNextNode: line [
 	"line is assumed to be of the form 'chararacters some text' e.g., '> some text'
 	the prefix spaces after $> are removed"
@@ -50,14 +52,14 @@ MicContinuousMarkedBlock >> addLineAndReturnNextNode: line [
 		ifNotNil: [ text , String cr , treatedLine ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicContinuousMarkedBlock >> canConsumeLine: line [
 	"return if this block can consume line i.e., it starts with sensible characters, e.g., > "
 
 	^ self doesLineStartWithMarkup: line
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicContinuousMarkedBlock >> doesLineStartWithMarkup: line [
 	"return if the line starts with a markup"
 
@@ -65,23 +67,23 @@ MicContinuousMarkedBlock >> doesLineStartWithMarkup: line [
 	
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MicContinuousMarkedBlock >> extractLine: line [
 	^ (line copyFrom: self lineMarkup size + 1 to: line size) trim
 ]
 
-{ #category : #markups }
+{ #category : 'markups' }
 MicContinuousMarkedBlock >> lineMarkup [
 
 	^ self subclassResponsibility 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicContinuousMarkedBlock >> text [
 	^ text
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicContinuousMarkedBlock >> text: aString [
 	text := aString
 ]

--- a/src/Microdown/MicDocumentListBlock.class.st
+++ b/src/Microdown/MicDocumentListBlock.class.st
@@ -1,39 +1,41 @@
 Class {
-	#name : #MicDocumentListBlock,
-	#superclass : #MicAnnotationBlock,
-	#category : #'Microdown-Extensions'
+	#name : 'MicDocumentListBlock',
+	#superclass : 'MicAnnotationBlock',
+	#category : 'Microdown-Extensions',
+	#package : 'Microdown',
+	#tag : 'Extensions'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicDocumentListBlock class >> tag [ 
 	^ #documentlist
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicDocumentListBlock >> accept: aVisitor [
 
 	"^ aVisitor visitDocListAnnotation: self"
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicDocumentListBlock >> limit [
 
 	^ self arguments at: #limit ifAbsent: [ '3' ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicDocumentListBlock >> path [
 
 	^ self arguments at: #path
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicDocumentListBlock >> sort [
 
 	^ self arguments at: #sort ifAbsent: [ '' ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicDocumentListBlock >> summaryMaxSize [
 
 	^ self arguments at: #summaryMaxSize
@@ -41,7 +43,7 @@ MicDocumentListBlock >> summaryMaxSize [
 		ifAbsent: [ 500 ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicDocumentListBlock >> templates [
 
 	^ self arguments at: #templates ifAbsent: [ #() ]

--- a/src/Microdown/MicElement.class.st
+++ b/src/Microdown/MicElement.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #MicElement,
-	#superclass : #Object,
+	#name : 'MicElement',
+	#superclass : 'Object',
 	#instVars : [
 		'parent',
 		'properties'
@@ -8,10 +8,12 @@ Class {
 	#pools : [
 		'MicMicrodownSharedPool'
 	],
-	#category : #'Microdown-Model'
+	#category : 'Microdown-Model',
+	#package : 'Microdown',
+	#tag : 'Model'
 }
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 MicElement class >> buildMicroDownUsing: aBuilder  withComment: aComment [
 	 | visitSelector visitors |
 	super buildMicroDownUsing: aBuilder  withComment: aComment.
@@ -33,18 +35,18 @@ MicElement class >> buildMicroDownUsing: aBuilder  withComment: aComment [
 				visitors  do:  [:class |  aBuilder  item:  [ aBuilder monospace: (class name, '>>#', visitSelector ) ]]]]
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MicElement class >> extensionClassFor: tag [
 	"I am a utility method used in extension blocks to find the right subclass to instantiate"
 	^ self allSubclasses detect: [ :each | each tag = tag ] ifNone: [ self ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicElement >> accept: aVisitor [
 	self subclassResponsibility 
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 MicElement >> hasProperty: aKey [
 	"Answer whether there is a property named aKey."
 	
@@ -52,7 +54,7 @@ MicElement >> hasProperty: aKey [
 	^ properties includesKey: aKey
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 MicElement >> inlineParse: aString [
 	| inlineParser inlinedChildren |
 	
@@ -64,48 +66,48 @@ MicElement >> inlineParse: aString [
 
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MicElement >> inlineParserClass [
 
 	^ MicInlineParser
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MicElement >> newInlineParser [
 
 	^ self inlineParserClass new
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicElement >> parent [
 	^ parent
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicElement >> parent: aBlock [
 	parent := aBlock.
 	aBlock addChild: self
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 MicElement >> properties [
 	^ properties ifNil: [ properties := Dictionary new ]
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 MicElement >> propertiesCopy [
 	self properties ifNil: [ ^ nil ].
 	^ self properties collect: [ :each | each copy ]
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 MicElement >> propertyAt: aKey [
 	"Answer the property value associated with aKey."
 	
 	^ self propertyAt: aKey ifAbsent: [ MicPropertyError signal: 'Property not found' ]
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 MicElement >> propertyAt: aKey ifAbsent: aBlock [
 	"Answer the property value associated with aKey or, if aKey isn't found, answer the result of evaluating aBlock."
 	
@@ -114,28 +116,28 @@ MicElement >> propertyAt: aKey ifAbsent: aBlock [
 		ifFalse: [ self properties at: aKey ifAbsent: aBlock ]
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 MicElement >> propertyAt: aKey ifAbsentPut: aBlock [
 	"Answer the property associated with aKey or, if aKey isn't found store the result of evaluating aBlock as new value."
 	
 	^ self propertyAt: aKey ifAbsent: [ self propertyAt: aKey put: aBlock value ]
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 MicElement >> propertyAt: aKey put: anObject [
 	"Set the property at aKey to be anObject. If aKey is not found, create a new entry for aKey and set is value to anObject. Answer anObject."
 
 	^ self properties at: aKey put: anObject
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 MicElement >> removeProperty: aKey [
 	"Remove the property with aKey. Answer the property or raise an error if aKey isn't found."
 	
 	^ self removeProperty: aKey ifAbsent: [ MicPropertyError signal: 'Property not found' ]
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 MicElement >> removeProperty: aKey ifAbsent: aBlock [
 	"Remove the property with aKey. Answer the value or, if aKey isn't found, answer the result of evaluating aBlock."
 	
@@ -146,7 +148,7 @@ MicElement >> removeProperty: aKey ifAbsent: aBlock [
 	^ answer
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 MicElement >> resolveFrom: aBase [
 	Microdown resolveDocument: self withBase: aBase
 ]

--- a/src/Microdown/MicEnvironmentBlock.class.st
+++ b/src/Microdown/MicEnvironmentBlock.class.st
@@ -43,15 +43,17 @@ This is important to support better column in the future:
 
 "
 Class {
-	#name : #MicEnvironmentBlock,
-	#superclass : #MicStartStopMarkupBlock,
+	#name : 'MicEnvironmentBlock',
+	#superclass : 'MicStartStopMarkupBlock',
 	#instVars : [
 		'arguments'
 	],
-	#category : #'Microdown-Model'
+	#category : 'Microdown-Model',
+	#package : 'Microdown',
+	#tag : 'Model'
 }
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 MicEnvironmentBlock class >> addDocumentDefinedEnvironments: aBuilder [
 	| currentDefinedTags |
 	currentDefinedTags := self allSubclasses collect: [ :subclass | subclass tag -> subclass name].
@@ -68,7 +70,7 @@ MicEnvironmentBlock class >> addDocumentDefinedEnvironments: aBuilder [
 		 ]
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 MicEnvironmentBlock class >> alternateBlockClassFor: line [
 
 	"If there is one subclass with the corresponding tag, returns it, else resturn the current class."
@@ -81,19 +83,19 @@ MicEnvironmentBlock class >> alternateBlockClassFor: line [
 	^ self extensionClassFor: tag
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 MicEnvironmentBlock class >> buildMicroDownUsing: aBuilder withComment: aString [
 	
 	super buildMicroDownUsing: aBuilder withComment: aString.
 	self addDocumentDefinedEnvironments: aBuilder
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicEnvironmentBlock >> accept: aVisitor [
  	^ aVisitor visitEnvironment: self
 ]
 
-{ #category : #handle }
+{ #category : 'handle' }
 MicEnvironmentBlock >> addLineAndReturnNextNode: line [
 	"add line to this node. 
 	Notice, the action is allowed to create new nodes in the block tree.
@@ -111,25 +113,25 @@ MicEnvironmentBlock >> addLineAndReturnNextNode: line [
 	^ self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicEnvironmentBlock >> arguments [
 	
 	^ arguments
 ]
 
-{ #category : #'parse support' }
+{ #category : 'parse support' }
 MicEnvironmentBlock >> body [
 
 	^ String streamContents: [:s |  self bodyElements do: [ :each | s nextPutAll: each substring ] ]
 ]
 
-{ #category : #'parse support' }
+{ #category : 'parse support' }
 MicEnvironmentBlock >> bodyElements [
 
 	^ children
 ]
 
-{ #category : #'parse support' }
+{ #category : 'parse support' }
 MicEnvironmentBlock >> bodyFromLine: line [
 	
 	| newBlock |
@@ -138,7 +140,7 @@ MicEnvironmentBlock >> bodyFromLine: line [
 	^ newBlock
 ]
 
-{ #category : #'parse support' }
+{ #category : 'parse support' }
 MicEnvironmentBlock >> closeMe [
 
 	"this is a temporary solution because normally the parser should populate body with MicBlocks.
@@ -153,12 +155,12 @@ MicEnvironmentBlock >> closeMe [
 		defaultValue: ''.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicEnvironmentBlock >> environmentName [
 	^ arguments at: #environmentName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicEnvironmentBlock >> extractFirstLineFrom: aLine [
 	"we got <! env ...x !> foo bar or <! env ...x and we return env ...x "
 	
@@ -174,13 +176,13 @@ MicEnvironmentBlock >> extractFirstLineFrom: aLine [
 		ifFalse: [ firstLine ]
 ]
 
-{ #category : #markups }
+{ #category : 'markups' }
 MicEnvironmentBlock >> lineStartMarkup [
 
 	^ EnvironmentOpeningBlockMarkup 
 ]
 
-{ #category : #markups }
+{ #category : 'markups' }
 MicEnvironmentBlock >> lineStopMarkup [
 	
 	^ EnvironmentClosingBlockMarkup 

--- a/src/Microdown/MicEvaluatedBlock.class.st
+++ b/src/Microdown/MicEvaluatedBlock.class.st
@@ -2,42 +2,44 @@
 I represent blocks with sub structure. Typically italics inside bold
 "
 Class {
-	#name : #MicEvaluatedBlock,
-	#superclass : #MicInlineElement,
+	#name : 'MicEvaluatedBlock',
+	#superclass : 'MicInlineElement',
 	#instVars : [
 		'children'
 	],
-	#category : #'Microdown-InlineParser'
+	#category : 'Microdown-InlineParser',
+	#package : 'Microdown',
+	#tag : 'InlineParser'
 }
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 MicEvaluatedBlock class >> blockName [
 	^ (super blockName) "withoutSuffix: 'Format'"
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 MicEvaluatedBlock class >> parse: token stream: aTokenStream for: aParser [
 	^ aParser parseEvaluatedBlock: self token: token stream: aTokenStream
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicEvaluatedBlock >> children [
 
 	^ children
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicEvaluatedBlock >> children: anObject [
 
 	children := anObject
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MicEvaluatedBlock >> plainText [
 	^ (self children collect: #plainText) joinUsing: ' '
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MicEvaluatedBlock >> printOn: stream [
 	stream << self blockName << '{ '.
 	children do: [ :ch | ch printOn: stream. stream nextPut: Character space  ].
@@ -45,21 +47,21 @@ MicEvaluatedBlock >> printOn: stream [
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicEvaluatedBlock >> textElement [
 	"Should only be used for tests"
 	self deprecated: 'Just use children' transformWith: '`@rec textElement' -> '`@rec children first'.
 	^ children first
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicEvaluatedBlock >> textElement: elem [
 	"Should only be used for tests"
 	self deprecated: 'Just use children' transformWith: '`@rec textElement: `@arg' -> '`@rec children: {`@arg}'.
 	^ children := { elem }
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicEvaluatedBlock >> wrappedElements [
 	self deprecated: 'Just use children' transformWith: '`@rec wrappedElements' -> '`@rec children'.
 	^ children 

--- a/src/Microdown/MicFigureBlock.class.st
+++ b/src/Microdown/MicFigureBlock.class.st
@@ -11,29 +11,31 @@ I have a resources, i.e. an object referencing either a file (in relative or abs
 What is important to see is that there is a space between the url arguments and microdown arguments. 
 "
 Class {
-	#name : #MicFigureBlock,
-	#superclass : #MicInlineBlockWithUrl,
-	#category : #'Microdown-InlineParser'
+	#name : 'MicFigureBlock',
+	#superclass : 'MicInlineBlockWithUrl',
+	#category : 'Microdown-InlineParser',
+	#package : 'Microdown',
+	#tag : 'InlineParser'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicFigureBlock class >> closingDelimiter [
 
  	^ NameCloserUrlOpener
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicFigureBlock class >> openingDelimiter [
 
  	^ FigureNameOpenerMarkup
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicFigureBlock >> accept: aVisitor [
  	^ aVisitor visitFigure: self
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MicFigureBlock >> plainText [
 	^ '![', ((self children collect: #plainText) joinUsing: ' '), '](', url ,')'
 ]

--- a/src/Microdown/MicFileResourceReference.class.st
+++ b/src/Microdown/MicFileResourceReference.class.st
@@ -17,15 +17,17 @@ You can get an instance of me from a pharo `FileReference` using `MicFileResourc
 The test class `MicFileResourceTest` has two tests `testLoadImage` and `testLoadMicrodown` which show how to use me.
 "
 Class {
-	#name : #MicFileResourceReference,
-	#superclass : #MicAbsoluteResourceReference,
+	#name : 'MicFileResourceReference',
+	#superclass : 'MicAbsoluteResourceReference',
 	#instVars : [
 		'filesystem'
 	],
-	#category : #'Microdown-Core'
+	#category : 'Microdown-Core',
+	#package : 'Microdown',
+	#tag : 'Core'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MicFileResourceReference class >> fromFileRef: aFileReference [
 	"return an instance of me which references aFileReference"
 	| znUrl |
@@ -37,12 +39,12 @@ MicFileResourceReference class >> fromFileRef: aFileReference [
 		filesystem: aFileReference fileSystem 
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MicFileResourceReference class >> handlesUriScheme: scheme [
 	^ scheme = 'file'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicFileResourceReference >> binaryReadStream [
 	[^ self fileReference binaryReadStream]
 	on: FileDoesNotExistException 
@@ -50,13 +52,13 @@ MicFileResourceReference >> binaryReadStream [
 		error resignalAs: (MicResourceReferenceError new messageText: 'Microdown file not found')  ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicFileResourceReference >> canSave [
 	"return true if I implement contents: "
 	^true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicFileResourceReference >> contents [
 	[^ self fileReference isDirectory ifTrue: [''] ifFalse: [self fileReference contents] ]
 	on: FileDoesNotExistException 
@@ -64,7 +66,7 @@ MicFileResourceReference >> contents [
 		error resignalAs: (MicResourceReferenceError new messageText: 'Microdown file not found')  ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicFileResourceReference >> contents: aString [
 	"write the contents of a string to my file"
 	|fileRef|
@@ -73,44 +75,44 @@ MicFileResourceReference >> contents: aString [
 	self fileReference writeStreamDo: [ :stream | stream nextPutAll: aString ].
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicFileResourceReference >> fileReference [ 
 	^ self filesystem referenceTo: self path
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicFileResourceReference >> filesystem [
 	^ filesystem
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicFileResourceReference >> filesystem: anObject [
 
 	filesystem := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicFileResourceReference >> fullName [ 
 	^ self path
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MicFileResourceReference >> initialize [
 	super initialize.
 	filesystem := FileSystem disk.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicFileResourceReference >> isDirectory [
 	^ self fileReference isDirectory 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicFileResourceReference >> isMicrodownResourceFileReference [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicFileResourceReference >> loadChildren [
 	"return a collection of MifResourceReferences if I am a directory, empty if I am not a directory"
 	self isDirectory ifFalse: [ ^ #() ].

--- a/src/Microdown/MicFootnoteBlock.class.st
+++ b/src/Microdown/MicFootnoteBlock.class.st
@@ -4,23 +4,25 @@ I'm an inline element that represents a footnote as in LaTeX for example. The bi
 this is a text with a `{!footnote|note=Here is a nice footenote.!}`
 "
 Class {
-	#name : #MicFootnoteBlock,
-	#superclass : #MicAnnotationBlock,
-	#category : #'Microdown-Extensions'
+	#name : 'MicFootnoteBlock',
+	#superclass : 'MicAnnotationBlock',
+	#category : 'Microdown-Extensions',
+	#package : 'Microdown',
+	#tag : 'Extensions'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicFootnoteBlock class >> tag [
 
 	^ #footnote
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicFootnoteBlock >> accept: aVisitor [
 	aVisitor visitFootnote: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicFootnoteBlock >> note [
 	arguments ifNotEmpty: [ 
 		^ arguments at: #note ifAbsent: [ '' ] ]

--- a/src/Microdown/MicHTTPResourceReference.class.st
+++ b/src/Microdown/MicHTTPResourceReference.class.st
@@ -4,15 +4,17 @@ I am a http reference encapsulating a http uri (`http//host/path/to/some/file.md
 
 "
 Class {
-	#name : #MicHTTPResourceReference,
-	#superclass : #MicAbsoluteResourceReference,
+	#name : 'MicHTTPResourceReference',
+	#superclass : 'MicAbsoluteResourceReference',
 	#classVars : [
 		'ResourcesCache'
 	],
-	#category : #'Microdown-Core'
+	#category : 'Microdown-Core',
+	#package : 'Microdown',
+	#tag : 'Core'
 }
 
-{ #category : #private }
+{ #category : 'private' }
 MicHTTPResourceReference class >> bytesForUrl: url [
 	"I do the offline and isCachingResources logic
 	In particular notice that #getBytesByHttp: throws an 
@@ -27,7 +29,7 @@ MicHTTPResourceReference class >> bytesForUrl: url [
 		ifFalse: [ ^ self getBytesByHttp: url ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MicHTTPResourceReference class >> getBytesByHttp: uri [
 	| client |
 	[(client := ZnEasy client)
@@ -41,12 +43,12 @@ MicHTTPResourceReference class >> getBytesByHttp: uri [
 			error resignalAs: (MicResourceReferenceError new messageText: 'Could not access ', uri printString)  ].
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MicHTTPResourceReference class >> handlesUriScheme: scheme [
 	^ scheme beginsWith: 'http'
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 MicHTTPResourceReference class >> initialize [
 	"self initialize"
 
@@ -54,36 +56,36 @@ MicHTTPResourceReference class >> initialize [
 	self resetResourcesCache
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicHTTPResourceReference class >> isCachingResources [
 
 	^ Microdown isCachingResources 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicHTTPResourceReference class >> offline [
 	^ Microdown offline
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicHTTPResourceReference class >> resetResourcesCache [ 
 
 	ResourcesCache := nil 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicHTTPResourceReference class >> resourcesCache [
 
 	ResourcesCache ifNil: [ ResourcesCache := LRUCache new ].
 	^ ResourcesCache
 ]
 
-{ #category : #streams }
+{ #category : 'streams' }
 MicHTTPResourceReference >> binaryReadStream [
 	^ (self class bytesForUrl: self uri) readStream 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicHTTPResourceReference >> contents [
 	^ (self class bytesForUrl: self uri) utf8Decoded.
 ]

--- a/src/Microdown/MicHeaderBlock.class.st
+++ b/src/Microdown/MicHeaderBlock.class.st
@@ -23,20 +23,22 @@ produces
 
 "
 Class {
-	#name : #MicHeaderBlock,
-	#superclass : #MicSingleLineBlock,
+	#name : 'MicHeaderBlock',
+	#superclass : 'MicSingleLineBlock',
 	#instVars : [
 		'level'
 	],
-	#category : #'Microdown-Model'
+	#category : 'Microdown-Model',
+	#package : 'Microdown',
+	#tag : 'Model'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicHeaderBlock >> accept: aVisitor [ 
  	^ aVisitor visitHeader: self
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 MicHeaderBlock >> addLineAndReturnNextNode: line [
 	"Line is on the form '#### my heading at forth level'"
 	self level: ('(#+)' asRegex
@@ -46,38 +48,38 @@ MicHeaderBlock >> addLineAndReturnNextNode: line [
 	^ self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicHeaderBlock >> formattedCode [ 
 	^super formattedCode , '[ ', self level printString, '/', self header, ' ]'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicHeaderBlock >> header [
 	"I am used to get an adhoc string for the header"
 	^ String streamContents: [ :s | 
 		  children do: [ :e | s nextPutAll: e bodystring ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicHeaderBlock >> headerElements [
 	
 	^ self children
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicHeaderBlock >> headerElements: aCollection [
 	
 	children := aCollection
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicHeaderBlock >> level [
 	^ level
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicHeaderBlock >> level: anInteger [
 	"(anInteger between: 1 and: 6) ifFalse: [ MicParsingError signal: 'header levels must be between 1 and 6' ]."
 	level := anInteger beBetween: 1 and: 6

--- a/src/Microdown/MicHorizontalLineBlock.class.st
+++ b/src/Microdown/MicHorizontalLineBlock.class.st
@@ -4,12 +4,14 @@ I'm an horizontal line. I'm expressed by using a new line with `***`
 *** the rest of the line is ignored.
 "
 Class {
-	#name : #MicHorizontalLineBlock,
-	#superclass : #MicSingleLineBlock,
-	#category : #'Microdown-Model'
+	#name : 'MicHorizontalLineBlock',
+	#superclass : 'MicSingleLineBlock',
+	#category : 'Microdown-Model',
+	#package : 'Microdown',
+	#tag : 'Model'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicHorizontalLineBlock >> accept: aVisitor [ 
  	^ aVisitor visitHorizontalLine: self
 ]

--- a/src/Microdown/MicInlineAlternativesDelimiter.class.st
+++ b/src/Microdown/MicInlineAlternativesDelimiter.class.st
@@ -6,15 +6,17 @@ I add bold also with `__`, and italic with `*`.
 
 "
 Class {
-	#name : #MicInlineAlternativesDelimiter,
-	#superclass : #MicInlineStandardDelimiter,
+	#name : 'MicInlineAlternativesDelimiter',
+	#superclass : 'MicInlineStandardDelimiter',
 	#pools : [
 		'MicMicrodownSharedPool'
 	],
-	#category : #'Microdown-InlineParser'
+	#category : 'Microdown-InlineParser',
+	#package : 'Microdown',
+	#tag : 'InlineParser'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MicInlineAlternativesDelimiter class >> initializeDelimiters [
 	"formating"
 	self new markup: '__'; blockClass: MicBoldFormatBlock; closer: '__'; addMe.

--- a/src/Microdown/MicInlineBlockWithUrl.class.st
+++ b/src/Microdown/MicInlineBlockWithUrl.class.st
@@ -8,66 +8,68 @@ My subclasses manage figures and links.
 ![Pharologo](https://files.pharo.org/media/logo/logo.png)
 "
 Class {
-	#name : #MicInlineBlockWithUrl,
-	#superclass : #MicInlineElement,
+	#name : 'MicInlineBlockWithUrl',
+	#superclass : 'MicInlineElement',
 	#instVars : [
 		'children',
 		'url',
 		'reference',
 		'arguments'
 	],
-	#category : #'Microdown-InlineParser'
+	#category : 'Microdown-InlineParser',
+	#package : 'Microdown',
+	#tag : 'InlineParser'
 }
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 MicInlineBlockWithUrl class >> parse: token stream: aTokenStream for: aParser [
 	^ aParser parseNameUrlBlock: self from: aTokenStream token: token
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicInlineBlockWithUrl >> anchor [
 	^ self arguments 
 		at: #anchor 
 		ifAbsent: [ nil ] 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineBlockWithUrl >> arguments [
 
 	^ arguments
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineBlockWithUrl >> arguments: anObject [
 
 	arguments := anObject
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicInlineBlockWithUrl >> captionElements [
 	self deprecated: 'Use children instead' transformWith: '`@rec captionElements' -> '`@rec children'.
 	^ children
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicInlineBlockWithUrl >> captionElements: someChildren [
 	self deprecated: 'Use children: instead' transformWith: '`@rec captionElements: `@arg' -> '`@rec children: `@arg'.
 	children := someChildren 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineBlockWithUrl >> children [
 
 	^ children
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineBlockWithUrl >> children: anObject [
 
 	children := anObject
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicInlineBlockWithUrl >> closeMe [
 	"the link url - ![alt text](url) - url is allowed to have title in quotes
 	(url ""title"") "
@@ -80,23 +82,23 @@ MicInlineBlockWithUrl >> closeMe [
 	self arguments: (MicArgumentList withString: title)
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicInlineBlockWithUrl >> hasAnchor [
 
 	^ self anchor isNotNil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicInlineBlockWithUrl >> hasArguments [
 	^ arguments size > 0
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MicInlineBlockWithUrl >> initialize [
 	arguments := OrderedDictionary new.
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MicInlineBlockWithUrl >> printOn: stream [
 	stream << self blockName << '{ '.
 	children do: [ :ch | ch printOn: stream. stream nextPut: Character space  ].
@@ -105,25 +107,25 @@ MicInlineBlockWithUrl >> printOn: stream [
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineBlockWithUrl >> reference [
 
 	^ reference
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineBlockWithUrl >> reference: anObject [
 
 	reference := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineBlockWithUrl >> url [
 
 	^ url
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineBlockWithUrl >> url: anObject [
 
 	url := anObject

--- a/src/Microdown/MicInlineDelimiter.class.st
+++ b/src/Microdown/MicInlineDelimiter.class.st
@@ -7,55 +7,57 @@ My class side method `initializeDelimiters` gathers delimiters from my subclasse
 
 "
 Class {
-	#name : #MicInlineDelimiter,
-	#superclass : #Object,
+	#name : 'MicInlineDelimiter',
+	#superclass : 'Object',
 	#classVars : [
 		'DelimiterDictionary'
 	],
 	#pools : [
 		'MicMicrodownSharedPool'
 	],
-	#category : #'Microdown-InlineParser'
+	#category : 'Microdown-InlineParser',
+	#package : 'Microdown',
+	#tag : 'InlineParser'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineDelimiter class >> all [
 	DelimiterDictionary ifNil: [ self initializeDelimiters ].
 	^ DelimiterDictionary values
 ]
 
-{ #category : #'private utilities' }
+{ #category : 'private utilities' }
 MicInlineDelimiter class >> allRegex [
 	^ ((MicInlineDelimiter all collect: #markupAsRegex) joinUsing: '|') asRegex
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineDelimiter class >> at: markup [
 	"return delimiter at markup, or nil"
 	^ DelimiterDictionary at: markup ifAbsent: [ nil ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MicInlineDelimiter class >> initialize [
 	<script>
 	DelimiterDictionary := nil
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MicInlineDelimiter class >> initializeDelimiters [
 	self = MicInlineDelimiter ifFalse: [ ^self ].
 	DelimiterDictionary := Dictionary new.
 	self allSubclasses do: [ :class | class initializeDelimiters ]
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 MicInlineDelimiter class >> noteCompilationOf: aSelector meta: isMeta [
 	"I reset when any method is recompiled"
 	self initialize
 ]
 
-{ #category : #'private utilities' }
+{ #category : 'private utilities' }
 MicInlineDelimiter class >> regexNot: markup [
 	"return a regular expression (string), which is recognizing anything but markup"
 	| str prefix|
@@ -70,45 +72,45 @@ MicInlineDelimiter class >> regexNot: markup [
 	^ str contents
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 MicInlineDelimiter >> addMe [
 	"add me to the dictionary in my class"
 	DelimiterDictionary at: self markup put: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineDelimiter >> blockClass [
 	self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineDelimiter >> closer [
 	self subclassResponsibility
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicInlineDelimiter >> isEvaluated [
 	"I am an opener whose resultering block will need further inline parsing"
 	^ self isOpener and: [self blockClass isEvaluated ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicInlineDelimiter >> isOpener [
 	^ self closer notNil or: [ self markup = self closer ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicInlineDelimiter >> isRawkind [
 	"I am an opener whose resulting nodes body is not further parsed"
 	^ self isOpener and: [ self blockClass isEvaluated not ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineDelimiter >> markup [
 	self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineDelimiter >> markupAsRegex [
 	self subclassResponsibility
 ]

--- a/src/Microdown/MicInlineElement.class.st
+++ b/src/Microdown/MicInlineElement.class.st
@@ -10,65 +10,67 @@ I am characterized by:
 
 "
 Class {
-	#name : #MicInlineElement,
-	#superclass : #MicElement,
-	#category : #'Microdown-InlineParser'
+	#name : 'MicInlineElement',
+	#superclass : 'MicElement',
+	#category : 'Microdown-InlineParser',
+	#package : 'Microdown',
+	#tag : 'InlineParser'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineElement class >> blockName [
 	^ (self instanceSide name asString withoutPrefix: 'Mic') withoutSuffix: 'Block'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineElement class >> closingDelimiter [
 	^ self subclassResponsibility
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicInlineElement class >> isEvaluated [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineElement class >> openingDelimiter [
 	^ self subclassResponsibility
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicInlineElement >> accept: dummy [
 	"implemented in subclasses"
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineElement >> blockName [
 	^ self class blockName
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicInlineElement >> closeMe [
 	"use for post parsing initialization"
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineElement >> closingDelimiter [ 
 	^ self class closingDelimiter
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MicInlineElement >> inlineParserClass [
 
 	^ MicInlineParser
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineElement >> kind [
 	"Should only be used for tests"
 	self deprecated: 'use blockName instead' transformWith: '`@rec kind' -> '`@rec blockName asLowercase'.
 	^ self blockName asLowercase 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineElement >> openingDelimiter [
 	^ self class openingDelimiter
 ]

--- a/src/Microdown/MicInlineHttpBlock.class.st
+++ b/src/Microdown/MicInlineHttpBlock.class.st
@@ -3,24 +3,26 @@ I implement the inline use of `https://somewhere.com` as a link directly in micr
 My parse method on the class side transform me directly into a MicLinkBlock, and as such, I am never instantiated
 "
 Class {
-	#name : #MicInlineHttpBlock,
-	#superclass : #MicUnEvaluatedBlock,
-	#category : #'Microdown-InlineParser'
+	#name : 'MicInlineHttpBlock',
+	#superclass : 'MicUnEvaluatedBlock',
+	#category : 'Microdown-InlineParser',
+	#package : 'Microdown',
+	#tag : 'InlineParser'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineHttpBlock class >> closingDelimiter [
 	"I am never instantiated, but transformed into a MicLinkBlock"
 	^ self shouldNotImplement 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineHttpBlock class >> openingDelimiter [
 	"I am never instantiated, but transformed into a MicLinkBlock"
 	^ self shouldNotImplement 
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 MicInlineHttpBlock class >> parse: delimiter stream: aTokenStream for: aParser [
 	"I transform myself into a MicLinkBlock"
 	^ MicLinkBlock new
@@ -29,7 +31,7 @@ MicInlineHttpBlock class >> parse: delimiter stream: aTokenStream for: aParser [
 		closeMe
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicInlineHttpBlock >> accept: dummy [
 	self error: 'I should not be instantiatied and used by visitor'
 ]

--- a/src/Microdown/MicInlineHttpDelimiter.class.st
+++ b/src/Microdown/MicInlineHttpDelimiter.class.st
@@ -5,42 +5,44 @@ I have an unfortunate restiction, if I am inlined in an other inline block, I sh
 Forexample `**https://somewhere.org_**` (`_` representing Character space)
 "
 Class {
-	#name : #MicInlineHttpDelimiter,
-	#superclass : #MicInlineDelimiter,
+	#name : 'MicInlineHttpDelimiter',
+	#superclass : 'MicInlineDelimiter',
 	#pools : [
 		'MicMicrodownSharedPool'
 	],
-	#category : #'Microdown-InlineParser'
+	#category : 'Microdown-InlineParser',
+	#package : 'Microdown',
+	#tag : 'InlineParser'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MicInlineHttpDelimiter class >> initializeDelimiters [
 	self new addMe.
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineHttpDelimiter >> blockClass [
 	^ MicInlineHttpBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineHttpDelimiter >> closer [
 	^ String space
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicInlineHttpDelimiter >> isRawkind [
 	"I am an opener whose resulting nodes body is not further parsed"
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineHttpDelimiter >> markup [
 	^ 'http'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineHttpDelimiter >> markupAsRegex [
 	^ 'http(s)?\://[\S]+' 
 ]

--- a/src/Microdown/MicInlineParser.class.st
+++ b/src/Microdown/MicInlineParser.class.st
@@ -4,20 +4,22 @@ I am a parser for paragraphs with substructure in Microdown.
 My only external method is `parse:`.
 "
 Class {
-	#name : #MicInlineParser,
-	#superclass : #Object,
+	#name : 'MicInlineParser',
+	#superclass : 'Object',
 	#pools : [
 		'MicMicrodownSharedPool'
 	],
-	#category : #'Microdown-InlineParser'
+	#category : 'Microdown-InlineParser',
+	#package : 'Microdown',
+	#tag : 'InlineParser'
 }
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 MicInlineParser class >> parse: string [
 	^ self new parse: string
 ]
 
-{ #category : #'block creation' }
+{ #category : 'block creation' }
 MicInlineParser >> createInlineBlock: token inStream: aReadStream [ 
 	| blockClass newBlock|
 	blockClass := token delimiter blockClass.
@@ -27,12 +29,12 @@ MicInlineParser >> createInlineBlock: token inStream: aReadStream [
 	
 ]
 
-{ #category : #'block creation' }
+{ #category : 'block creation' }
 MicInlineParser >> createTextBlock: token [
 	^ MicTextBlock new bodystring: token
 ]
 
-{ #category : #'private parsing' }
+{ #category : 'private parsing' }
 MicInlineParser >> joinTextNodesOf: children [
 	"children might have several text blocks following each other - join them and remove empty Text blocks"
 	| outStream bufferText  |
@@ -55,7 +57,7 @@ MicInlineParser >> joinTextNodesOf: children [
 	 ^ outStream contents asArray
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 MicInlineParser >> parse: aString [
 	"I return an array of inline blocks"
 	| tokenStream |
@@ -63,7 +65,7 @@ MicInlineParser >> parse: aString [
 	^ (self parseChildrenIn: tokenStream) asArray 
 ]
 
-{ #category : #'private parsing' }
+{ #category : 'private parsing' }
 MicInlineParser >> parseChildrenIn: tokenStream [
 	"return an array of blocks from parsing tokenStream"
 	| children child |
@@ -79,7 +81,7 @@ MicInlineParser >> parseChildrenIn: tokenStream [
 	^ self joinTextNodesOf: children
 ]
 
-{ #category : #'private parsing' }
+{ #category : 'private parsing' }
 MicInlineParser >> parseEvaluatedBlock: blockType token: token stream: tokenStream [
 	| skipRes |
 	skipRes := (self skipTo: token delimiter closer inStream: tokenStream).
@@ -90,7 +92,7 @@ MicInlineParser >> parseEvaluatedBlock: blockType token: token stream: tokenStre
 		closeMe
 ]
 
-{ #category : #'private parsing' }
+{ #category : 'private parsing' }
 MicInlineParser >> parseNameUrlBlock: blockType from: aTokenStream token: token [
 	| skipRes children urlToken|
 	skipRes := (self skipToUrlStartInStream: aTokenStream).
@@ -106,14 +108,14 @@ MicInlineParser >> parseNameUrlBlock: blockType from: aTokenStream token: token 
 
 ]
 
-{ #category : #'private parsing' }
+{ #category : 'private parsing' }
 MicInlineParser >> parseNonEvaluatedBlock: blockClass token: token stream: aTokenStream [
 	^ blockClass new
 		bodystring: token undelimitedSubstring;
 		closeMe
 ]
 
-{ #category : #'private parsing' }
+{ #category : 'private parsing' }
 MicInlineParser >> skipTo: closer inStream: tokenStream [
 	"skip tokenStream to closer, ignore closers in non-evaluated. if we find it return the accumulates text and a subtokenstream to read it from"
 	| startPos substringStream |
@@ -133,7 +135,7 @@ MicInlineParser >> skipTo: closer inStream: tokenStream [
 	
 ]
 
-{ #category : #'private parsing' }
+{ #category : 'private parsing' }
 MicInlineParser >> skipToUrlStartInStream: tokenStream [
 	"Skip to my UrlStart. Notice, I might find a nested url construct"
 	| startPos substringStream nestingLevel|

--- a/src/Microdown/MicInlineStandardDelimiter.class.st
+++ b/src/Microdown/MicInlineStandardDelimiter.class.st
@@ -2,8 +2,8 @@
 I define the standard inline delimiters
 "
 Class {
-	#name : #MicInlineStandardDelimiter,
-	#superclass : #MicInlineDelimiter,
+	#name : 'MicInlineStandardDelimiter',
+	#superclass : 'MicInlineDelimiter',
 	#instVars : [
 		'markup',
 		'closer',
@@ -12,10 +12,12 @@ Class {
 	#pools : [
 		'MicMicrodownSharedPool'
 	],
-	#category : #'Microdown-InlineParser'
+	#category : 'Microdown-InlineParser',
+	#package : 'Microdown',
+	#tag : 'InlineParser'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MicInlineStandardDelimiter class >> initializeDelimiters [
 	"The fixious text delimiter"
 	self new markup: FixiousTextDelimiter; blockClass: MicTextBlock; closer: nil; addMe.
@@ -41,43 +43,43 @@ MicInlineStandardDelimiter class >> initializeDelimiters [
 		
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineStandardDelimiter >> blockClass [
 
 	^ blockClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineStandardDelimiter >> blockClass: anObject [
 
 	blockClass := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineStandardDelimiter >> closer [
 
 	^ closer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineStandardDelimiter >> closer: anObject [
 
 	closer := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineStandardDelimiter >> markup [
 
 	^ markup
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineStandardDelimiter >> markup: anObject [
 
 	markup := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineStandardDelimiter >> markupAsRegex [
 	"return a regex (as string) matching this delimiter"
 	| str |
@@ -91,7 +93,7 @@ MicInlineStandardDelimiter >> markupAsRegex [
 	^ str contents
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MicInlineStandardDelimiter >> printOn: stream [
 	stream << $« << markup << $»
 ]

--- a/src/Microdown/MicInlineToken.class.st
+++ b/src/Microdown/MicInlineToken.class.st
@@ -6,8 +6,8 @@ I have two instance variables:
 - delimiter, which is a reference to a subclass of MicAbstractDelimiter
 "
 Class {
-	#name : #MicInlineToken,
-	#superclass : #Object,
+	#name : 'MicInlineToken',
+	#superclass : 'Object',
 	#instVars : [
 		'delimiter',
 		'string'
@@ -15,39 +15,41 @@ Class {
 	#pools : [
 		'MicMicrodownSharedPool'
 	],
-	#category : #'Microdown-InlineParser'
+	#category : 'Microdown-InlineParser',
+	#package : 'Microdown',
+	#tag : 'InlineParser'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineToken >> delimiter [
 
 	^ delimiter
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineToken >> delimiter: anObject [
 
 	delimiter := anObject
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MicInlineToken >> printOn: aStream [
 	aStream << delimiter printString << $( << string << $)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineToken >> string [
 
 	^ string
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineToken >> string: anObject [
 
 	string := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInlineToken >> undelimitedSubstring [
 	"assume I am a token for a unevaluated delimiter, containing raw body - remove my delimiters"
 	^string 

--- a/src/Microdown/MicInlineTokenStream.class.st
+++ b/src/Microdown/MicInlineTokenStream.class.st
@@ -3,18 +3,20 @@ I am a stream of tokens.
 I have some logic for assigning delimiter types to the tokens as I build them.
 "
 Class {
-	#name : #MicInlineTokenStream,
-	#superclass : #Object,
+	#name : 'MicInlineTokenStream',
+	#superclass : 'Object',
 	#instVars : [
 		'tokens'
 	],
 	#pools : [
 		'MicMicrodownSharedPool'
 	],
-	#category : #'Microdown-InlineParser'
+	#category : 'Microdown-InlineParser',
+	#package : 'Microdown',
+	#tag : 'InlineParser'
 }
 
-{ #category : #'escape character' }
+{ #category : 'escape character' }
 MicInlineTokenStream class >> backslashDecode: aString [
 	"I convert all encoded chars back to their original (without the leading escape character)"
 	"My sister method escapeEncode encodes into the format I decode from"
@@ -33,7 +35,7 @@ MicInlineTokenStream class >> backslashDecode: aString [
 	
 ]
 
-{ #category : #'escape character' }
+{ #category : 'escape character' }
 MicInlineTokenStream class >> backslashEncode: aString [
 	"I convert all escaped characters (eg '\`' or '\\') into special characters which are not used in Microdown"
 	"My sister method escapeDecode reverts back"
@@ -51,7 +53,7 @@ MicInlineTokenStream class >> backslashEncode: aString [
 	
 ]
 
-{ #category : #'escape character' }
+{ #category : 'escape character' }
 MicInlineTokenStream class >> backslashReescape: aString except: keep [
 	"I convert all encoded back to escaped chars, except the characters in keep"
 	"My sister method escapeEncode encodes into the format I decode from"
@@ -71,7 +73,7 @@ MicInlineTokenStream class >> backslashReescape: aString except: keep [
 	
 ]
 
-{ #category : #'escape character' }
+{ #category : 'escape character' }
 MicInlineTokenStream class >> magicCharacter [
 	"All escaped characters are moved out of range. 
 	The unicode range Private Use Area is used, 
@@ -79,12 +81,12 @@ MicInlineTokenStream class >> magicCharacter [
 	^ 16r100000 "Private Use Area-B"
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MicInlineTokenStream class >> on: escapedStream [
 	^ self new tokenize: escapedStream 
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 MicInlineTokenStream >> addDelimiter: string [
 	| delimiter decodedString|
 	delimiter := (MicInlineDelimiter at: string)
@@ -97,7 +99,7 @@ MicInlineTokenStream >> addDelimiter: string [
 		delimiter: delimiter)
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 MicInlineTokenStream >> addText: matchedString [
 	| token |
 	token := MicInlineToken new 
@@ -106,12 +108,12 @@ MicInlineTokenStream >> addText: matchedString [
 	tokens add: token
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MicInlineTokenStream >> initialize [
 	tokens := OrderedCollection new
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 MicInlineTokenStream >> tokenize: rawString [
 	| inlineString splits from|
 	inlineString := self class backslashEncode: rawString.

--- a/src/Microdown/MicInputfileBlock.class.st
+++ b/src/Microdown/MicInputfileBlock.class.st
@@ -16,23 +16,25 @@ Gives:
 
 "
 Class {
-	#name : #MicInputfileBlock,
-	#superclass : #MicEnvironmentBlock,
-	#category : #'Microdown-Model'
+	#name : 'MicInputfileBlock',
+	#superclass : 'MicEnvironmentBlock',
+	#category : 'Microdown-Model',
+	#package : 'Microdown',
+	#tag : 'Model'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInputfileBlock class >> tag [ 
 	^ #inputFile
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicInputfileBlock >> accept: aVisitor [
 
 	aVisitor visitInputFile: self
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicInputfileBlock >> closeMe [
 	super closeMe.
 	(arguments includesKey: #path)
@@ -40,41 +42,41 @@ MicInputfileBlock >> closeMe [
 		ifFalse: [ self path: (MicResourceReference fromUri: 'error: inputFile should have a path argument')]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInputfileBlock >> fileWithConfiguration: aConfiguration [
 	"I search my file."
 	self flag: 'can be better to use the MicPathResolver'.
 	^ aConfiguration baseDirectory resolve: self path
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicInputfileBlock >> isRelativeFilePath [
 	^ (self path beginsWith: '/') not
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInputfileBlock >> originalPath [
 	^ self properties at: #originalPath ifAbsent: [ self path ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInputfileBlock >> path [
 	
 	^ self arguments at: #path  ifAbsent: [ 'path is absent' ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInputfileBlock >> path: aPath [
 	
 	arguments at: #'path' put: aPath
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInputfileBlock >> reference [
 	^ self arguments at: #path
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicInputfileBlock >> reference: aMicResourceReference [
 
 	self arguments at: #path put: aMicResourceReference

--- a/src/Microdown/MicItalicFormatBlock.class.st
+++ b/src/Microdown/MicItalicFormatBlock.class.st
@@ -2,24 +2,26 @@
 I represent an italic text section. I'm delimited using `_` as in `_italic_` to obtain _italic_.
 "
 Class {
-	#name : #MicItalicFormatBlock,
-	#superclass : #MicEvaluatedBlock,
-	#category : #'Microdown-InlineParser'
+	#name : 'MicItalicFormatBlock',
+	#superclass : 'MicEvaluatedBlock',
+	#category : 'Microdown-InlineParser',
+	#package : 'Microdown',
+	#tag : 'InlineParser'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicItalicFormatBlock class >> closingDelimiter [
 
  	^ ItalicMarkup
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicItalicFormatBlock class >> openingDelimiter [
 
  	^ ItalicMarkup
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicItalicFormatBlock >> accept: aVisitor [
 	^ aVisitor visitItalic: self
 ]

--- a/src/Microdown/MicLinkBlock.class.st
+++ b/src/Microdown/MicLinkBlock.class.st
@@ -2,29 +2,31 @@
 I represent a reference in a text. For example `[http://pharo.org](http://pharo.org)` creates [http://pharo.org](http://pharo.org).
 "
 Class {
-	#name : #MicLinkBlock,
-	#superclass : #MicInlineBlockWithUrl,
-	#category : #'Microdown-InlineParser'
+	#name : 'MicLinkBlock',
+	#superclass : 'MicInlineBlockWithUrl',
+	#category : 'Microdown-InlineParser',
+	#package : 'Microdown',
+	#tag : 'InlineParser'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicLinkBlock class >> closingDelimiter [
 
  	^ NameCloserUrlOpener
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicLinkBlock class >> openingDelimiter [
 
  	^ LinkNameOpenerMarkup
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicLinkBlock >> accept: aVisitor [
 	^ aVisitor visitLink: self
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MicLinkBlock >> plainText [
 	^ '[', ((self children collect: #plainText) joinUsing: ' '), '](', url ,')'
 ]

--- a/src/Microdown/MicListBlock.class.st
+++ b/src/Microdown/MicListBlock.class.st
@@ -42,16 +42,18 @@ Now an ordered list can also contain an unordered list.
 
 "
 Class {
-	#name : #MicListBlock,
-	#superclass : #MicAbstractBlock,
+	#name : 'MicListBlock',
+	#superclass : 'MicAbstractBlock',
 	#instVars : [
 		'indent',
 		'nestedLevel'
 	],
-	#category : #'Microdown-Model'
+	#category : 'Microdown-Model',
+	#package : 'Microdown',
+	#tag : 'Model'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicListBlock >> addLineAndReturnNextNode: inLine [
 	"Create a new item, and insert it into me.
 	line is on the format 'markup text'"
@@ -68,7 +70,7 @@ MicListBlock >> addLineAndReturnNextNode: inLine [
 		addLineAndReturnNextNode: (line copyFrom: indent - parent indent to: line size)
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicListBlock >> canConsumeLine: line [
 	"to consume this line there must be a ListItem starting at the right indentation"
 	
@@ -78,24 +80,24 @@ MicListBlock >> canConsumeLine: line [
 	^true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicListBlock >> closeMe [
 	super closeMe.
 	nestedLevel := self computeNestedLevel
 ]
 
-{ #category : #indent }
+{ #category : 'indent' }
 MicListBlock >> computeNestedLevel [
 	
 	^ self parent computeNestedLevel + 1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicListBlock >> indent [
 	^ indent
 ]
 
-{ #category : #indent }
+{ #category : 'indent' }
 MicListBlock >> indentFromLine: aLine [
 	"The line is expected to have the form: '<bullet> space+ [text]', where bullet is one of *,+,- or 1. or 1). More than one space is allowed. 
 	indentFromLine returns the position of the last character before the text.
@@ -108,7 +110,7 @@ MicListBlock >> indentFromLine: aLine [
 	indent := parent indent + (regEx subexpression: 1) size
 ]
 
-{ #category : #indent }
+{ #category : 'indent' }
 MicListBlock >> nestedLevel [
 	"Return the nesting level of main blocks. Basically only list increases this."
 	

--- a/src/Microdown/MicListItemBlock.class.st
+++ b/src/Microdown/MicListItemBlock.class.st
@@ -40,20 +40,22 @@ Pay attention my instance variable text is only used during the parsing time.
 
 "
 Class {
-	#name : #MicListItemBlock,
-	#superclass : #MicAbstractBlock,
+	#name : 'MicListItemBlock',
+	#superclass : 'MicAbstractBlock',
 	#instVars : [
 		'text'
 	],
-	#category : #'Microdown-Model'
+	#category : 'Microdown-Model',
+	#package : 'Microdown',
+	#tag : 'Model'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicListItemBlock >> accept: aVisitor [
  	^ aVisitor visitListItem: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicListItemBlock >> addLineAndReturnNextNode: line [
 	"add line to this node. 
 	Notice, the action is allowed to create new nodes in the block tree.
@@ -77,52 +79,52 @@ MicListItemBlock >> addLineAndReturnNextNode: line [
 			text := text , String cr , normalized ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicListItemBlock >> canConsumeLine: line [
 	"return if this block can consume line"
 
 	^ line beginsWith: (' ' repeat: parent indent)
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicListItemBlock >> closeMe [
 
 	super closeMe.
 	self inlineParse: text
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicListItemBlock >> computeNestedLevel [
 	"An item has the same nested level than its parent."
 	^ self parent computeNestedLevel
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicListItemBlock >> isAList: normalized [
 
 	^ parser isAList: normalized
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicListItemBlock >> nestedLevel [
 	"Return the nesting level of main blocks. Basically only list increases this."
 	
 	^ self parent nestedLevel 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicListItemBlock >> testText [
 	"I am used to make it easier to write tests"
 	^ String streamContents: [ :str | children do: [ :each | str nextPutAll: each printString ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicListItemBlock >> text [
 	self deprecated: 'Use testText instead' transformWith: '`@rec text' -> '`@rec testText'.
 	^ self testText 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicListItemBlock >> textElements [ 
 	self deprecated: 'I should not be used, use children' transformWith: '`@rec textElements' -> '`@rec children'.
 	^ children  

--- a/src/Microdown/MicMathBlock.class.st
+++ b/src/Microdown/MicMathBlock.class.st
@@ -20,23 +20,25 @@ $$
 
 "
 Class {
-	#name : #MicMathBlock,
-	#superclass : #MicSameStartStopMarkupBlock,
-	#category : #'Microdown-Model'
+	#name : 'MicMathBlock',
+	#superclass : 'MicSameStartStopMarkupBlock',
+	#category : 'Microdown-Model',
+	#package : 'Microdown',
+	#tag : 'Model'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicMathBlock >> accept: aVisitor [ 
  	^ aVisitor visitMath: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicMathBlock >> arguments [
 
 	^ arguments
 ]
 
-{ #category : #handle }
+{ #category : 'handle' }
 MicMathBlock >> extractFirstLineFrom: aLine [
 
 	| lineWithoutMarkup |
@@ -47,7 +49,7 @@ MicMathBlock >> extractFirstLineFrom: aLine [
 	^ lineWithoutMarkup
 ]
 
-{ #category : #markups }
+{ #category : 'markups' }
 MicMathBlock >> lineStartMarkup [
 	
 	^ MathOpeningBlockMarkup

--- a/src/Microdown/MicMathInlineBlock.class.st
+++ b/src/Microdown/MicMathInlineBlock.class.st
@@ -25,24 +25,26 @@ $f(a) = \frac{1}{2\pi i} \oint_{\gamma} \frac{f(z)}{z - a} dz$
 
 "
 Class {
-	#name : #MicMathInlineBlock,
-	#superclass : #MicUnEvaluatedBlock,
-	#category : #'Microdown-InlineParser'
+	#name : 'MicMathInlineBlock',
+	#superclass : 'MicUnEvaluatedBlock',
+	#category : 'Microdown-InlineParser',
+	#package : 'Microdown',
+	#tag : 'InlineParser'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicMathInlineBlock class >> closingDelimiter [
 
  	^ MathMarkup
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicMathInlineBlock class >> openingDelimiter [
 
  	^ MathMarkup
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicMathInlineBlock >> accept: aVisitor [
 	^ aVisitor visitMathInline: self
 ]

--- a/src/Microdown/MicMetaDataBlock.class.st
+++ b/src/Microdown/MicMetaDataBlock.class.st
@@ -16,32 +16,34 @@ In Microdown, metadata is a block level expressed as follows:
 This class should be packaged in a separate package because it requires the Pillar extension for books (i.e., package `#'Pillar-Model'`).
 "
 Class {
-	#name : #MicMetaDataBlock,
-	#superclass : #MicStartStopMarkupBlock,
+	#name : 'MicMetaDataBlock',
+	#superclass : 'MicStartStopMarkupBlock',
 	#instVars : [
 		'bogusParsing'
 	],
-	#category : #'Microdown-BookRelated'
+	#category : 'Microdown-BookRelated',
+	#package : 'Microdown',
+	#tag : 'BookRelated'
 }
 
-{ #category : #markups }
+{ #category : 'markups' }
 MicMetaDataBlock class >> keyForUnparsableContents [
 
 	^ 'unparsableContents'
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicMetaDataBlock >> accept: aVisitor [
 	^ aVisitor visitMetaData: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicMetaDataBlock >> bogusParsing [
 
 	^ bogusParsing
 ]
 
-{ #category : #markups }
+{ #category : 'markups' }
 MicMetaDataBlock >> closeMe [ 
 	super closeMe.
 	body := [ STONJSON fromString: '{', body, '}' ] on: STONReaderError do: [ :ex |
@@ -50,31 +52,31 @@ MicMetaDataBlock >> closeMe [
 		dict := Dictionary new at: self keyForUnparsableContents put: body; yourself ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MicMetaDataBlock >> initialize [ 
 	super initialize.
 	bogusParsing := false.
 ]
 
-{ #category : #markups }
+{ #category : 'markups' }
 MicMetaDataBlock >> keyForUnparsableContents [
 
 	^ self class keyForUnparsableContents
 ]
 
-{ #category : #markups }
+{ #category : 'markups' }
 MicMetaDataBlock >> lineStartMarkup [
 
 	^ MetaDataOpeningBlockMarkup
 ]
 
-{ #category : #markups }
+{ #category : 'markups' }
 MicMetaDataBlock >> lineStopMarkup [
 
 	^ MetaDataClosingBlockMarkup 
 ]
 
-{ #category : #markups }
+{ #category : 'markups' }
 MicMetaDataBlock >> printOn: aStream [
 
 	aStream nextPutAll: 'Metadata: '.

--- a/src/Microdown/MicMicrodownSharedPool.class.st
+++ b/src/Microdown/MicMicrodownSharedPool.class.st
@@ -2,8 +2,8 @@
 I define all the constants for parsing Microdown blocks.
 "
 Class {
-	#name : #MicMicrodownSharedPool,
-	#superclass : #SharedPool,
+	#name : 'MicMicrodownSharedPool',
+	#superclass : 'SharedPool',
 	#classVars : [
 		'AnchorMarkup',
 		'AnchorReferenceCloserMarkup',
@@ -47,10 +47,12 @@ Class {
 		'UnorderedListPlusMarkup',
 		'UnorderedListStarMarkup'
 	],
-	#category : #'Microdown-Parser'
+	#category : 'Microdown-Parser',
+	#package : 'Microdown',
+	#tag : 'Parser'
 }
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 MicMicrodownSharedPool class >> initialize [
 	"self initialize"
 	

--- a/src/Microdown/MicMicrodownTextualBuilder.class.st
+++ b/src/Microdown/MicMicrodownTextualBuilder.class.st
@@ -14,16 +14,18 @@ In particular since ordered and unordered do not have the same indentation lengt
 we would have to know all the nested path and not just the level.
 "
 Class {
-	#name : #MicMicrodownTextualBuilder,
-	#superclass : #MicAbstractMicrodownTextualBuilder,
+	#name : 'MicMicrodownTextualBuilder',
+	#superclass : 'MicAbstractMicrodownTextualBuilder',
 	#instVars : [
 		'prefixStack',
 		'currentLevel'
 	],
-	#category : #'Microdown-Parser'
+	#category : 'Microdown-Parser',
+	#package : 'Microdown',
+	#tag : 'Parser'
 }
 
-{ #category : #'element - annotated' }
+{ #category : 'element - annotated' }
 MicMicrodownTextualBuilder >> anchor: aLabel [
 
 	self raw: AnchorMarkup.
@@ -31,7 +33,7 @@ MicMicrodownTextualBuilder >> anchor: aLabel [
 
 ]
 
-{ #category : #'element - format' }
+{ #category : 'element - format' }
 MicMicrodownTextualBuilder >> anchorReference: aText [
 
 	self raw: AnchorReferenceOpenerMarkup.
@@ -39,7 +41,7 @@ MicMicrodownTextualBuilder >> anchorReference: aText [
 	self raw: AnchorReferenceCloserMarkup.
 ]
 
-{ #category : #'element - annotated' }
+{ #category : 'element - annotated' }
 MicMicrodownTextualBuilder >> annotated: annotation paragraph:  aBlock [
 	"!!Important 
 	
@@ -49,7 +51,7 @@ MicMicrodownTextualBuilder >> annotated: annotation paragraph:  aBlock [
 
 ]
 
-{ #category : #'element - annotated' }
+{ #category : 'element - annotated' }
 MicMicrodownTextualBuilder >> annotatedAnnotation: annotation [
 	"I'm made to be followed by a paragraph. I manage the space between the annotation/label and the paragraph."
 	
@@ -62,7 +64,7 @@ MicMicrodownTextualBuilder >> annotatedAnnotation: annotation [
 
 ]
 
-{ #category : #'element - annotated' }
+{ #category : 'element - annotated' }
 MicMicrodownTextualBuilder >> annotation: aString arguments: aDictionary [
 
 	self raw: AnnotationOpenerMarkup.
@@ -77,26 +79,26 @@ MicMicrodownTextualBuilder >> annotation: aString arguments: aDictionary [
 	self raw: AnnotationCloserMarkup
 ]
 
-{ #category : #'element - format' }
+{ #category : 'element - format' }
 MicMicrodownTextualBuilder >> bold: aBlock [
 	self raw: BoldMarkup.
 	aBlock value.
 	self raw: BoldMarkup.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicMicrodownTextualBuilder >> cell: aCellBlock [
 	self raw: '| '.
 	aCellBlock value.
 	self raw: ' '
 ]
 
-{ #category : #'element - code block' }
+{ #category : 'element - code block' }
 MicMicrodownTextualBuilder >> codeblock: aString [ 
 	self codeblock: aString firstLineAssociations: #() 
 ]
 
-{ #category : #'element - code block' }
+{ #category : 'element - code block' }
 MicMicrodownTextualBuilder >> codeblock: aString firstLineAssociations: aCol [
 	self raw: CodeblockMarkup.
 	aCol do: [ :each | self 
@@ -112,7 +114,7 @@ MicMicrodownTextualBuilder >> codeblock: aString firstLineAssociations: aCol [
 	self newLine.
 ]
 
-{ #category : #'element - code block' }
+{ #category : 'element - code block' }
 MicMicrodownTextualBuilder >> codeblock: aString firstLineAssociations: aCol withCaption: aCaptionBlock [
 	self raw: CodeblockMarkup.
 	aCol do: [ :each | self 
@@ -130,7 +132,7 @@ MicMicrodownTextualBuilder >> codeblock: aString firstLineAssociations: aCol wit
 	self newLine.
 ]
 
-{ #category : #'element - code block' }
+{ #category : 'element - code block' }
 MicMicrodownTextualBuilder >> codeblockTag: aTag withBody: aString [
 	self flag: #fixme. 
 	"missing first line stuff and we need a block for value of keys
@@ -146,7 +148,7 @@ MicMicrodownTextualBuilder >> codeblockTag: aTag withBody: aString [
 	self raw: CodeblockMarkup.
 ]
 
-{ #category : #'element - slide' }
+{ #category : 'element - slide' }
 MicMicrodownTextualBuilder >> columnWidth: aString withBody: aBodyBlock [ 
 	self raw: EnvironmentOpeningBlockMarkup.
 	self raw: 'column|width='.
@@ -160,7 +162,7 @@ MicMicrodownTextualBuilder >> columnWidth: aString withBody: aBodyBlock [
 	self newLine.
 ]
 
-{ #category : #'element - slide' }
+{ #category : 'element - slide' }
 MicMicrodownTextualBuilder >> columnsWithBody: aBodyBlock [ 
 	
 	self raw: EnvironmentOpeningBlockMarkup.
@@ -173,7 +175,7 @@ MicMicrodownTextualBuilder >> columnsWithBody: aBodyBlock [
 	self newLine.
 ]
 
-{ #category : #'element - header' }
+{ #category : 'element - header' }
 MicMicrodownTextualBuilder >> comment: aText [
 	self 
 		withLinesIn: aText 
@@ -182,7 +184,7 @@ MicMicrodownTextualBuilder >> comment: aText [
 	
 ]
 
-{ #category : #'element - environment' }
+{ #category : 'element - environment' }
 MicMicrodownTextualBuilder >> environment: aName arguments: aCol [
 	self raw: EnvironmentOpeningBlockMarkup.
 	self raw: aName.
@@ -192,7 +194,7 @@ MicMicrodownTextualBuilder >> environment: aName arguments: aCol [
 	self raw: EnvironmentClosingBlockMarkup
 ]
 
-{ #category : #'element - environment' }
+{ #category : 'element - environment' }
 MicMicrodownTextualBuilder >> environment: aName body: aBodyBlock arguments: aCol [
 	
 	self raw: EnvironmentOpeningBlockMarkup.
@@ -205,7 +207,7 @@ MicMicrodownTextualBuilder >> environment: aName body: aBodyBlock arguments: aCo
 	self raw: EnvironmentClosingBlockMarkup
 ]
 
-{ #category : #'element - references' }
+{ #category : 'element - references' }
 MicMicrodownTextualBuilder >> externalLink: aURL withDescription: aDescriptionBlock [
 
 	self raw: LinkNameOpenerMarkup.
@@ -216,7 +218,7 @@ MicMicrodownTextualBuilder >> externalLink: aURL withDescription: aDescriptionBl
 	self raw: URLCloserMarkup.
 ]
 
-{ #category : #'element - figure' }
+{ #category : 'element - figure' }
 MicMicrodownTextualBuilder >> figureURL: aUrl withCaption: aDescriptionBlock [
 
 	self rawFigureDescription: aDescriptionBlock.
@@ -225,7 +227,7 @@ MicMicrodownTextualBuilder >> figureURL: aUrl withCaption: aDescriptionBlock [
 	self raw: URLCloserMarkup
 ]
 
-{ #category : #'element - figure' }
+{ #category : 'element - figure' }
 MicMicrodownTextualBuilder >> figureURL: aUrl withCaption: aDescriptionBlock withParameters: anOrderedDictionary [
 	"If you specify association of arguments then asSting is not the url but the url without the query part, i.e., http://www.pharo.org/figures/light.png"
 	self deprecated: 'Better use figureURLString:withCaption:withParameters:'.
@@ -245,7 +247,7 @@ MicMicrodownTextualBuilder >> figureURL: aUrl withCaption: aDescriptionBlock wit
 			self raw: URLCloserMarkup ]
 ]
 
-{ #category : #'element - figure' }
+{ #category : 'element - figure' }
 MicMicrodownTextualBuilder >> figureURLString: aString withCaption: aDescriptionBlock [
 	"aString can be 'http://www.pharo.org or http://www.pharo.org?width=80&language=en'"
 	
@@ -255,7 +257,7 @@ MicMicrodownTextualBuilder >> figureURLString: aString withCaption: aDescription
 	self raw: URLCloserMarkup.
 ]
 
-{ #category : #'element - figure' }
+{ #category : 'element - figure' }
 MicMicrodownTextualBuilder >> figureURLString: aString withCaption: aDescriptionBlock withParameters: anOrderedDictionary [
 	"If you specify association of arguments then asSting is not the url but the url without the query part, i.e., http://www.pharo.org/figures/light.png
 	
@@ -275,25 +277,25 @@ MicMicrodownTextualBuilder >> figureURLString: aString withCaption: aDescription
 			self raw: URLCloserMarkup ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicMicrodownTextualBuilder >> headCell [
 	self raw: '| --- '.
 ]
 
-{ #category : #'element - header' }
+{ #category : 'element - header' }
 MicMicrodownTextualBuilder >> header: aBloc withLevel: anInteger [
 	self rawHeader: aBloc withLevel: anInteger.
 	self newLine
 ]
 
-{ #category : #'element - header' }
+{ #category : 'element - header' }
 MicMicrodownTextualBuilder >> horizontalLine [
 	self raw: HorizontalLineMarkup.
    self newLine
 
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MicMicrodownTextualBuilder >> initialize [
 	super initialize.
 	prefixStack := OrderedCollection new.
@@ -301,7 +303,7 @@ MicMicrodownTextualBuilder >> initialize [
 	
 ]
 
-{ #category : #'element - annotated' }
+{ #category : 'element - annotated' }
 MicMicrodownTextualBuilder >> inputFile: aPathString [
 
 	self newLine.
@@ -311,13 +313,13 @@ MicMicrodownTextualBuilder >> inputFile: aPathString [
 	self raw: EnvironmentClosingBlockMarkup 
 ]
 
-{ #category : #'element - annotated' }
+{ #category : 'element - annotated' }
 MicMicrodownTextualBuilder >> inputfile: aPathString [
 	"deprecated"
 	self inputFile: aPathString
 ]
 
-{ #category : #'element - references' }
+{ #category : 'element - references' }
 MicMicrodownTextualBuilder >> internalLink: aLabel [
 	self 
 		writeText: aLabel 
@@ -326,14 +328,14 @@ MicMicrodownTextualBuilder >> internalLink: aLabel [
 	
 ]
 
-{ #category : #'element - format' }
+{ #category : 'element - format' }
 MicMicrodownTextualBuilder >> italic: aBlock [
 	self raw: ItalicMarkup.
 	aBlock value.
 	self raw: ItalicMarkup
 ]
 
-{ #category : #'element - list' }
+{ #category : 'element - list' }
 MicMicrodownTextualBuilder >> item: aBlock [
 
 	self raw: (self startOfUnorderedListForLevel: currentLevel).
@@ -341,7 +343,7 @@ MicMicrodownTextualBuilder >> item: aBlock [
 	self potentialNewLine.
 ]
 
-{ #category : #'ugly line handling' }
+{ #category : 'ugly line handling' }
 MicMicrodownTextualBuilder >> lines: aString [
 	"Output aString and take care of line ending within aString."
 	| str |
@@ -354,7 +356,7 @@ MicMicrodownTextualBuilder >> lines: aString [
 	 ]
 ]
 
-{ #category : #'element - format' }
+{ #category : 'element - format' }
 MicMicrodownTextualBuilder >> mathInline: aText [
 
 	self raw: MathMarkup.
@@ -362,7 +364,7 @@ MicMicrodownTextualBuilder >> mathInline: aText [
 	self raw: MathMarkup.
 ]
 
-{ #category : #'element - math' }
+{ #category : 'element - math' }
 MicMicrodownTextualBuilder >> mathblock: aString [ 
 
 	self raw: MathOpeningBlockMarkup.
@@ -373,7 +375,7 @@ MicMicrodownTextualBuilder >> mathblock: aString [
 	self newLine.
 ]
 
-{ #category : #'element - math' }
+{ #category : 'element - math' }
 MicMicrodownTextualBuilder >> mathblock: aString firstLineAssociations: aCol [
 
 	self raw: MathOpeningBlockMarkup.
@@ -390,7 +392,7 @@ MicMicrodownTextualBuilder >> mathblock: aString firstLineAssociations: aCol [
 	self newLine.
 ]
 
-{ #category : #'element - math' }
+{ #category : 'element - math' }
 MicMicrodownTextualBuilder >> mathblock: aString firstLineAssociations: aCol withCaption: aCaptionBlock [
 
 	self raw: MathOpeningBlockMarkup.
@@ -409,13 +411,13 @@ MicMicrodownTextualBuilder >> mathblock: aString firstLineAssociations: aCol wit
 	self newLine.
 ]
 
-{ #category : #'element - metadata' }
+{ #category : 'element - metadata' }
 MicMicrodownTextualBuilder >> metaDataFrom: aDictionary [ 
 
 	self metaDataFromAssociations: aDictionary associations
 ]
 
-{ #category : #'element - metadata' }
+{ #category : 'element - metadata' }
 MicMicrodownTextualBuilder >> metaDataFromAssociations: aCollection [ 
 	self raw: '{'; newLine.
 	aCollection do: [ :each | 
@@ -429,7 +431,7 @@ MicMicrodownTextualBuilder >> metaDataFromAssociations: aCollection [
 	self newLine; raw: '}'.
 ]
 
-{ #category : #'ugly line handling' }
+{ #category : 'ugly line handling' }
 MicMicrodownTextualBuilder >> nextPutAllLines: aString [
 	self 
 		withLinesIn: aString 
@@ -437,7 +439,7 @@ MicMicrodownTextualBuilder >> nextPutAllLines: aString [
 		separatedBy: [ self newLine ]
 ]
 
-{ #category : #'element - list' }
+{ #category : 'element - list' }
 MicMicrodownTextualBuilder >> orderedItem: aBlock [
 
 	self raw: (self startOfOrderedListForLevel: currentLevel).
@@ -446,7 +448,7 @@ MicMicrodownTextualBuilder >> orderedItem: aBlock [
 	
 ]
 
-{ #category : #'element - list' }
+{ #category : 'element - list' }
 MicMicrodownTextualBuilder >> orderedItem: aBlock startingAt: aNumber [
 
 	self writeStartOfOrderedListIndex: aNumber.
@@ -454,7 +456,7 @@ MicMicrodownTextualBuilder >> orderedItem: aBlock startingAt: aNumber [
 	self newLine.
 ]
 
-{ #category : #'element - list' }
+{ #category : 'element - list' }
 MicMicrodownTextualBuilder >> orderedListDuring: aBlockClosure [
 	"For list we do not emit empty line at the end because we do not want to force the creation of a paragraph 
 	in the middle of nested list. And from a builder point of view this is difficult to know it."
@@ -472,32 +474,32 @@ MicMicrodownTextualBuilder >> orderedListDuring: aBlockClosure [
 		
 ]
 
-{ #category : #'element - paragraph' }
+{ #category : 'element - paragraph' }
 MicMicrodownTextualBuilder >> paragraph: aBlock [
 
 	self rawParagraph: aBlock.
 	self newLine
 ]
 
-{ #category : #'private utilities' }
+{ #category : 'private utilities' }
 MicMicrodownTextualBuilder >> popPrefix [
 	
 	prefixStack removeLast
 ]
 
-{ #category : #'private utilities' }
+{ #category : 'private utilities' }
 MicMicrodownTextualBuilder >> pushPrefix: aString [ 
 	
 	prefixStack addLast: aString
 ]
 
-{ #category : #'element - quote block' }
+{ #category : 'element - quote block' }
 MicMicrodownTextualBuilder >> quoteBlock: aText [
 
 	self writeText: aText beginsWith: PreformattedMarkup
 ]
 
-{ #category : #'writing low-level' }
+{ #category : 'writing low-level' }
 MicMicrodownTextualBuilder >> raw: aString [
 	"We have in the prefix potentially many nesting level '> ', '```' and for each new line 
 	we want to make sure that prefixes are written prior to aString.
@@ -515,7 +517,7 @@ MicMicrodownTextualBuilder >> raw: aString [
 	lastIsNewLine := false
 ]
 
-{ #category : #'element - annotated' }
+{ #category : 'element - annotated' }
 MicMicrodownTextualBuilder >> rawAnnotated: annotation paragraph:  aBlock [
 	"!!Important 
 	
@@ -529,7 +531,7 @@ MicMicrodownTextualBuilder >> rawAnnotated: annotation paragraph:  aBlock [
 
 ]
 
-{ #category : #'element - figure' }
+{ #category : 'element - figure' }
 MicMicrodownTextualBuilder >> rawFigureDescription: aBlock [
 
 	self raw: FigureNameOpenerMarkup.
@@ -537,7 +539,7 @@ MicMicrodownTextualBuilder >> rawFigureDescription: aBlock [
 	self raw: LinkNameCloserMarkup
 ]
 
-{ #category : #'element - format' }
+{ #category : 'element - format' }
 MicMicrodownTextualBuilder >> rawFormat: aText [
 
 	self raw: RawOpenerMarkup.
@@ -545,7 +547,7 @@ MicMicrodownTextualBuilder >> rawFormat: aText [
 	self raw: RawCloserMarkup.
 ]
 
-{ #category : #'writing low-level' }
+{ #category : 'writing low-level' }
 MicMicrodownTextualBuilder >> rawHeader: aBloc withLevel: anInteger [
 
 	self raw: (HeaderMarkup repeat: anInteger).
@@ -557,13 +559,13 @@ MicMicrodownTextualBuilder >> rawHeader: aBloc withLevel: anInteger [
 	
 ]
 
-{ #category : #'ugly line handling' }
+{ #category : 'ugly line handling' }
 MicMicrodownTextualBuilder >> rawLines: aString [
 	"Output aString and take care of line ending within aString."
 	self withLinesIn: aString do: [ :line | self raw: line ] separatedBy: [ self newLine ]
 ]
 
-{ #category : #'writing low-level' }
+{ #category : 'writing low-level' }
 MicMicrodownTextualBuilder >> rawParagraph: aBlock [
 
 	aBlock value
@@ -573,7 +575,7 @@ MicMicrodownTextualBuilder >> rawParagraph: aBlock [
 	
 ]
 
-{ #category : #'element - figure' }
+{ #category : 'element - figure' }
 MicMicrodownTextualBuilder >> rawParameters: aZnDictionary [
 	"should be better to use do: separatedBy:"
 	
@@ -585,13 +587,13 @@ MicMicrodownTextualBuilder >> rawParameters: aZnDictionary [
 			self raw: ArgumentListDelimiter ] ]
 ]
 
-{ #category : #'ugly line handling' }
+{ #category : 'ugly line handling' }
 MicMicrodownTextualBuilder >> root: aBlock [
 	
 	aBlock value
 ]
 
-{ #category : #'element - slide' }
+{ #category : 'element - slide' }
 MicMicrodownTextualBuilder >> slideTitle: aString withBody: aBodyBlock [ 
 	
 	self raw: EnvironmentOpeningBlockMarkup.
@@ -605,26 +607,26 @@ MicMicrodownTextualBuilder >> slideTitle: aString withBody: aBodyBlock [
 	self newLine.
 ]
 
-{ #category : #'element - list' }
+{ #category : 'element - list' }
 MicMicrodownTextualBuilder >> startOfOrderedListForLevel: aNumber [
 
 	^ ('  ' repeat: aNumber) ,'1', OrderedListSemiMarkup
 ]
 
-{ #category : #'element - list' }
+{ #category : 'element - list' }
 MicMicrodownTextualBuilder >> startOfUnorderedListForLevel: aNumber [
 
 	^ ('  ' repeat: aNumber) , UnorderedListMarkup
 ]
 
-{ #category : #'element - format' }
+{ #category : 'element - format' }
 MicMicrodownTextualBuilder >> strike: aBlock [
 	self raw: StrikeMarkup.
 	aBlock value.
 	self raw: StrikeMarkup.
 ]
 
-{ #category : #'element - list' }
+{ #category : 'element - list' }
 MicMicrodownTextualBuilder >> unorderedListDuring: aBlockClosure [
 	"For list we do not emit empty line at the end because we do not want to force the creation of a paragraph 
 	in the middle of nested list. And from a builder point of view this is difficult to know it."
@@ -638,7 +640,7 @@ MicMicrodownTextualBuilder >> unorderedListDuring: aBlockClosure [
 	currentLevel := currentLevel - 1.
 ]
 
-{ #category : #'ugly line handling' }
+{ #category : 'ugly line handling' }
 MicMicrodownTextualBuilder >> withLinesIn: aString do: aBlock separatedBy: anotherBlock [
 	"this method shows that the body of code block is weak because it should encapsulate the way it internally represents lines. Now this is exposed in clients."
 	| str |
@@ -652,7 +654,7 @@ MicMicrodownTextualBuilder >> withLinesIn: aString do: aBlock separatedBy: anoth
 				ifFalse: anotherBlock ]
 ]
 
-{ #category : #'writing during' }
+{ #category : 'writing during' }
 MicMicrodownTextualBuilder >> writeIndentedCodeBlockDuring: aBlockClosure [ 
 	"The logic of writeIndentedCodeBlockDuring: only works if the raw: method managing the prefixes
 is invoked. Therefore somehow the blockclosure execution should invoke it.
@@ -663,7 +665,7 @@ It means that within the context of a visitor the visitText: method should do it
 		forEachLineDuring: aBlockClosure.
 ]
 
-{ #category : #'writing during' }
+{ #category : 'writing during' }
 MicMicrodownTextualBuilder >> writePrefix: aString forEachLineDuring: aBlockClosure [ 
 	"The logic of writePrefix:forEachLineDuring: only works if the raw: method managing the prefixes
 is invoked. Therefore somehow the blockclosure execution should invoke it.
@@ -672,7 +674,7 @@ It means that within the context of a visitor the visitText: method should do it
 	aBlockClosure ensure: [ self popPrefix ].
 ]
 
-{ #category : #'writing during' }
+{ #category : 'writing during' }
 MicMicrodownTextualBuilder >> writeQuoteCodeBlockDuring: aBlockClosure [ 
 	"The logic of writePrefix:forEachLineDuring: only works if the raw: method managing the prefixes
 is invoked. Therefore somehow the blockclosure execution should invoke it.
@@ -682,7 +684,7 @@ It means that within the context of a visitor the visitText: method should do it
 		forEachLineDuring: aBlockClosure
 ]
 
-{ #category : #'element - list' }
+{ #category : 'element - list' }
 MicMicrodownTextualBuilder >> writeStartOfOrderedListIndex: anInteger [
 	"does not handle for now nesting"
 	self raw: anInteger asString, OrderedListSemiMarkup

--- a/src/Microdown/MicMinimalConfiguration.class.st
+++ b/src/Microdown/MicMinimalConfiguration.class.st
@@ -1,26 +1,28 @@
 Class {
-	#name : #MicMinimalConfiguration,
-	#superclass : #Object,
+	#name : 'MicMinimalConfiguration',
+	#superclass : 'Object',
 	#instVars : [
 		'newLine',
 		'headingLevelOffset'
 	],
-	#category : #'Microdown-Utils'
+	#category : 'Microdown-Utils',
+	#package : 'Microdown',
+	#tag : 'Utils'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicMinimalConfiguration >> crAsNewLine [
 
 	self newLine: Character cr.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicMinimalConfiguration >> crlfAsNewLine [
 
 	self newLine: String crlf.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicMinimalConfiguration >> headingLevelOffset [
 	"To be moved in a subclass when we will deal with the pillar integration.
 	Check the senders: it should be a visitor that should be packaged out of Microdown and placed in Pillar-Microdown"
@@ -28,32 +30,32 @@ MicMinimalConfiguration >> headingLevelOffset [
 	^ headingLevelOffset
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicMinimalConfiguration >> headingLevelOffset: anObject [
 	"To be moved in a subclass when we will deal with the pillar integration."
 	
 	headingLevelOffset := anObject
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MicMinimalConfiguration >> initialize [ 
 	super initialize.
 	newLine := String crlf.
 	headingLevelOffset := 0
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicMinimalConfiguration >> lfAsNewLine [
 
 	self newLine: Character lf.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicMinimalConfiguration >> newLine [
 	^ newLine
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicMinimalConfiguration >> newLine: aString [
 	newLine := aString
 ]

--- a/src/Microdown/MicMonospaceFormatBlock.class.st
+++ b/src/Microdown/MicMonospaceFormatBlock.class.st
@@ -2,40 +2,42 @@
 I represent a monospaced text section. I'm delimited using `\`` as in `\`monospace\`` to obtain `monospace`.
 "
 Class {
-	#name : #MicMonospaceFormatBlock,
-	#superclass : #MicUnEvaluatedBlock,
-	#category : #'Microdown-InlineParser'
+	#name : 'MicMonospaceFormatBlock',
+	#superclass : 'MicUnEvaluatedBlock',
+	#category : 'Microdown-InlineParser',
+	#package : 'Microdown',
+	#tag : 'InlineParser'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicMonospaceFormatBlock class >> blockName [
 	^ (super blockName) withoutSuffix: 'Format'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicMonospaceFormatBlock class >> closingDelimiter [
 
  	^ MonospaceMarkup
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicMonospaceFormatBlock class >> openingDelimiter [
 
  	^ MonospaceMarkup
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicMonospaceFormatBlock >> accept: aVisitor [
 	^ aVisitor visitMonospace: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicMonospaceFormatBlock >> children [
 	"should be deprecated"
 	^ Array with: (MicTextBlock new bodystring: self bodystring)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicMonospaceFormatBlock >> text [
 	"should be deprecated "
 	^ self bodystring 

--- a/src/Microdown/MicOrderedListBlock.class.st
+++ b/src/Microdown/MicOrderedListBlock.class.st
@@ -25,20 +25,22 @@ Notice how the following line of the second item is indented with the previous o
 
 "
 Class {
-	#name : #MicOrderedListBlock,
-	#superclass : #MicListBlock,
+	#name : 'MicOrderedListBlock',
+	#superclass : 'MicListBlock',
 	#instVars : [
 		'startIndex'
 	],
-	#category : #'Microdown-Model'
+	#category : 'Microdown-Model',
+	#package : 'Microdown',
+	#tag : 'Model'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicOrderedListBlock >> accept: aVisitor [
  	^ aVisitor visitOrderedList: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicOrderedListBlock >> addLineAndReturnNextNode: line [
 	"Create a new item, and insert it into me."
 	"line is on the format '1. item text'"
@@ -51,7 +53,7 @@ MicOrderedListBlock >> addLineAndReturnNextNode: line [
 	^ super addLineAndReturnNextNode: line
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicOrderedListBlock >> canConsumeLine: line [
 	"to consume this line there must be a UnorderdListItem start at the right indentation"
 	
@@ -59,12 +61,12 @@ MicOrderedListBlock >> canConsumeLine: line [
 	^ (super canConsumeLine: line) and: [line trim  prefixMatchesRegex: '\d+(\.|\))']
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicOrderedListBlock >> startIndex [
 	^ startIndex
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicOrderedListBlock >> startIndexFrom: line [
 	startIndex ifNotNil: [ ^self ].
 	startIndex := line asInteger

--- a/src/Microdown/MicOutputStream.class.st
+++ b/src/Microdown/MicOutputStream.class.st
@@ -2,121 +2,123 @@
 I'm a little wrapper on stream to provide a nicer API. In particular I help not hardcoding line ending everywhere.
 "
 Class {
-	#name : #MicOutputStream,
-	#superclass : #Object,
+	#name : 'MicOutputStream',
+	#superclass : 'Object',
 	#instVars : [
 		'stream',
 		'configuration'
 	],
-	#category : #'Microdown-Utils'
+	#category : 'Microdown-Utils',
+	#package : 'Microdown',
+	#tag : 'Utils'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MicOutputStream class >> on: aStream [
 
 	^ self new setStream: aStream; yourself
 ]
 
-{ #category : #streaming }
+{ #category : 'streaming' }
 MicOutputStream >> << anObject [
 	anObject isBlock
 		ifTrue: anObject
 		ifFalse: [ stream << anObject ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicOutputStream >> configuration [ 
 	^ configuration
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicOutputStream >> configuration: aConfiguration [
 	configuration := aConfiguration 
 ]
 
-{ #category : #streaming }
+{ #category : 'streaming' }
 MicOutputStream >> contents [
 
 	^ stream contents
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicOutputStream >> crAsNewLine [
 
 	self configuration crAsNewLine
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicOutputStream >> crlfAsNewLine [
 
 	self configuration crlfAsNewLine
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicOutputStream >> flush [
 	stream flush
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MicOutputStream >> initialize [ 
 	super initialize.
 	configuration := MicMinimalConfiguration new.
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicOutputStream >> isEmpty [
 	
 	^ stream isEmpty
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicOutputStream >> lfAsNewLine [
 
 	self configuration lfAsNewLine
 ]
 
-{ #category : #streaming }
+{ #category : 'streaming' }
 MicOutputStream >> newLine [
 	self << self usedNewLine
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicOutputStream >> nextPut: aCharacter [ 
 	stream nextPut: aCharacter
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicOutputStream >> nextPutAll: aCharacter [ 
 	stream nextPutAll: aCharacter
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicOutputStream >> print: anObject [
 	stream print: anObject
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MicOutputStream >> setStream: aWriteStream [
 	stream := aWriteStream
 ]
 
-{ #category : #streaming }
+{ #category : 'streaming' }
 MicOutputStream >> space [
 	stream space
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MicOutputStream >> stream [
 
 	^ stream
 ]
 
-{ #category : #streaming }
+{ #category : 'streaming' }
 MicOutputStream >> tab [
 	stream tab
 ]
 
-{ #category : #streaming }
+{ #category : 'streaming' }
 MicOutputStream >> trimLastNewLine [
 	| newLine |
 	newLine := self usedNewLine.
@@ -125,7 +127,7 @@ MicOutputStream >> trimLastNewLine [
 	stream position: stream position - newLine size.
 ]
 
-{ #category : #streaming }
+{ #category : 'streaming' }
 MicOutputStream >> usedNewLine [
 	^ self configuration newLine
 ]

--- a/src/Microdown/MicParagraphBlock.class.st
+++ b/src/Microdown/MicParagraphBlock.class.st
@@ -4,25 +4,27 @@ I am a plain text paragraph.
 If am divided from other paragraphs by either a blank line, or one of the other markups.
 "
 Class {
-	#name : #MicParagraphBlock,
-	#superclass : #MicAbstractBlock,
+	#name : 'MicParagraphBlock',
+	#superclass : 'MicAbstractBlock',
 	#instVars : [
 		'text'
 	],
-	#category : #'Microdown-Model'
+	#category : 'Microdown-Model',
+	#package : 'Microdown',
+	#tag : 'Model'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MicParagraphBlock class >> opensBy: aLine [
 	^ aLine notEmpty 
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicParagraphBlock >> accept: aVisitor [
  	^ aVisitor visitParagraph: self
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 MicParagraphBlock >> addLineAndReturnNextNode: line [
 	"add line to this node. 
 	Notice, the action is allowed to create new nodes in the block tree.
@@ -31,7 +33,7 @@ MicParagraphBlock >> addLineAndReturnNextNode: line [
 	text := self appendLine: line to: text
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MicParagraphBlock >> appendLine: line to: aString [
 
 	^ aString
@@ -39,14 +41,14 @@ MicParagraphBlock >> appendLine: line to: aString [
 		ifNotNil: [ aString, String cr, line trim ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MicParagraphBlock >> asUnindented: line [
 	"return a line where the indentation to my indentation level has been removed"
 
 	^ line copyFrom: self indent + 1 to: line size
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 MicParagraphBlock >> canConsumeLine: line [
 	"A paragraph is closed by an empty line, "
 	| unIndented |
@@ -61,14 +63,14 @@ MicParagraphBlock >> canConsumeLine: line [
 	^ (self blockStarterClassFrom: unIndented) = self class
 ]
 
-{ #category : #'parse support' }
+{ #category : 'parse support' }
 MicParagraphBlock >> closeMe [
 
 	super closeMe.
 	self children: (self inlineParse: text)
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MicParagraphBlock >> isRightlyIndented: line [
 	"test if line has the appropriate number of spaces at first"
 
@@ -77,18 +79,18 @@ MicParagraphBlock >> isRightlyIndented: line [
 	^ line beginsWith: (' ' repeat: self indent)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicParagraphBlock >> text [
 	^ text
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicParagraphBlock >> textElements [
  
 	^ children
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicParagraphBlock >> textElements: aCollection [
  
 	children := aCollection

--- a/src/Microdown/MicParsingError.class.st
+++ b/src/Microdown/MicParsingError.class.st
@@ -5,20 +5,22 @@ I should be obsoleted.
 <!inputFile|pa=foo!> 
 "
 Class {
-	#name : #MicParsingError,
-	#superclass : #Error,
+	#name : 'MicParsingError',
+	#superclass : 'Error',
 	#instVars : [
 		'line'
 	],
-	#category : #'Microdown-Parser'
+	#category : 'Microdown-Parser',
+	#package : 'Microdown',
+	#tag : 'Parser'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicParsingError >> line [
 	^ line
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicParsingError >> line: anObject [
 	line := anObject
 ]

--- a/src/Microdown/MicPharoEvaluatorBlock.class.st
+++ b/src/Microdown/MicPharoEvaluatorBlock.class.st
@@ -7,29 +7,31 @@ Transcript show: 'Test'; cr.
 ```
 "
 Class {
-	#name : #MicPharoEvaluatorBlock,
-	#superclass : #MicScriptBlock,
-	#category : #'Microdown-Extensions'
+	#name : 'MicPharoEvaluatorBlock',
+	#superclass : 'MicScriptBlock',
+	#category : 'Microdown-Extensions',
+	#package : 'Microdown',
+	#tag : 'Extensions'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicPharoEvaluatorBlock class >> tag [
 
 	^ #pharoeval
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicPharoEvaluatorBlock >> accept: aVisitor [
 	^ aVisitor visitPharoEvaluator: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicPharoEvaluatorBlock >> label [
 
 	^ arguments at: #label ifAbsent: [ nil ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicPharoEvaluatorBlock >> title [
 	^ arguments at: 'title' ifAbsent: [ '' ]
 ]

--- a/src/Microdown/MicPharoImageResourceReference.class.st
+++ b/src/Microdown/MicPharoImageResourceReference.class.st
@@ -13,41 +13,43 @@ Examples:
 - Only string arguments can be passed
 "
 Class {
-	#name : #MicPharoImageResourceReference,
-	#superclass : #MicAbsoluteResourceReference,
-	#category : #'Microdown-Core'
+	#name : 'MicPharoImageResourceReference',
+	#superclass : 'MicAbsoluteResourceReference',
+	#category : 'Microdown-Core',
+	#package : 'Microdown',
+	#tag : 'Core'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MicPharoImageResourceReference class >> handlesUriScheme: scheme [
 	^ scheme = 'pharo'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicPharoImageResourceReference >> binaryReadStream [
 	"I am not needed, I implement loadImage directly"
 	^ self shouldBeImplemented
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicPharoImageResourceReference >> contents [
 	"I am not needed, I implement loadMicrodown directly"
 	^ self perform
 ]
 
-{ #category : #loading }
+{ #category : 'loading' }
 MicPharoImageResourceReference >> loadImage [
 	"Assume the method just returns a form"
 	^ self perform
 ]
 
-{ #category : #loading }
+{ #category : 'loading' }
 MicPharoImageResourceReference >> loadMicrodown [
 	"Assume the method just returns a document"
 	^ self perform
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MicPharoImageResourceReference >> perform [
 	"I assume the uri to have the form: 'pharo:///class/selector:/arg1/arg2"
 	| class selector size args |

--- a/src/Microdown/MicPharoScriptBlock.class.st
+++ b/src/Microdown/MicPharoScriptBlock.class.st
@@ -18,23 +18,25 @@ Morph new
 ```
 "
 Class {
-	#name : #MicPharoScriptBlock,
-	#superclass : #MicScriptBlock,
-	#category : #'Microdown-Extensions'
+	#name : 'MicPharoScriptBlock',
+	#superclass : 'MicScriptBlock',
+	#category : 'Microdown-Extensions',
+	#package : 'Microdown',
+	#tag : 'Extensions'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicPharoScriptBlock class >> tag [
 
 	^ #pharoscript
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicPharoScriptBlock >> accept: aVisitor [
 	^ aVisitor visitPharoScript: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicPharoScriptBlock >> title [
 	^ arguments at: 'title' ifAbsent: [ '' ]
 ]

--- a/src/Microdown/MicQuoteBlock.class.st
+++ b/src/Microdown/MicQuoteBlock.class.st
@@ -11,24 +11,26 @@ In githubmarkdown the definitions are just super complex and we do not follow th
 
 "
 Class {
-	#name : #MicQuoteBlock,
-	#superclass : #MicContinuousMarkedBlock,
-	#category : #'Microdown-Model'
+	#name : 'MicQuoteBlock',
+	#superclass : 'MicContinuousMarkedBlock',
+	#category : 'Microdown-Model',
+	#package : 'Microdown',
+	#tag : 'Model'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicQuoteBlock >> accept: aVisitor [
  	^ aVisitor visitQuote: self
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicQuoteBlock >> closeMe [
 	super closeMe.
 	
 	children := self inlineParse: text
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicQuoteBlock >> lineMarkup [
 
 	^ PreformattedMarkup

--- a/src/Microdown/MicRawBlock.class.st
+++ b/src/Microdown/MicRawBlock.class.st
@@ -6,24 +6,26 @@ Raw lets the user place anything (so don't use it).
 ```
 "
 Class {
-	#name : #MicRawBlock,
-	#superclass : #MicUnEvaluatedBlock,
-	#category : #'Microdown-InlineParser'
+	#name : 'MicRawBlock',
+	#superclass : 'MicUnEvaluatedBlock',
+	#category : 'Microdown-InlineParser',
+	#package : 'Microdown',
+	#tag : 'InlineParser'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicRawBlock class >> closingDelimiter [
 
  	^ RawCloserMarkup
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicRawBlock class >> openingDelimiter [
 
  	^ RawOpenerMarkup
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicRawBlock >> accept: aVisitor [
 	^ aVisitor visitRaw: self
 ]

--- a/src/Microdown/MicRelativeResourceReference.class.st
+++ b/src/Microdown/MicRelativeResourceReference.class.st
@@ -4,30 +4,32 @@ I am a relative reference.
 I specify a ressource relative to an other reference. One example is the path `../images/logo.png` which says the logo is in the image direcctory of my parent directory. However, I am unresolved, and need to be resolved with respect to an absolute reference (file or http). 
 "
 Class {
-	#name : #MicRelativeResourceReference,
-	#superclass : #MicResourceReference,
+	#name : 'MicRelativeResourceReference',
+	#superclass : 'MicResourceReference',
 	#instVars : [
 		'relativePath'
 	],
-	#category : #'Microdown-Core'
+	#category : 'Microdown-Core',
+	#package : 'Microdown',
+	#tag : 'Core'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicRelativeResourceReference >> fullName [ 
 	^ self path
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicRelativeResourceReference >> isRelative [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicRelativeResourceReference >> path [
 	^ self relativePath 
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MicRelativeResourceReference >> printOn: aStream [
 	super printOn: aStream.
 	aStream
@@ -36,13 +38,13 @@ MicRelativeResourceReference >> printOn: aStream [
 		nextPutAll: ')'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicRelativeResourceReference >> relativePath [
 
 	^ relativePath 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicRelativeResourceReference >> relativePath: aString [
 
 	relativePath := aString 

--- a/src/Microdown/MicResourceReference.class.st
+++ b/src/Microdown/MicResourceReference.class.st
@@ -26,12 +26,14 @@ It is possible to add new kinds of ResourceReferences. The idea is each ressourc
 
 "
 Class {
-	#name : #MicResourceReference,
-	#superclass : #Object,
-	#category : #'Microdown-Core'
+	#name : 'MicResourceReference',
+	#superclass : 'Object',
+	#category : 'Microdown-Core',
+	#package : 'Microdown',
+	#tag : 'Core'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MicResourceReference class >> fromUri: aString [
 	| uri refClass |
 	(aString beginsWith: '/')
@@ -46,32 +48,32 @@ MicResourceReference class >> fromUri: aString [
 	
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MicResourceReference class >> handlesUriScheme: scheme [
 	"Return true if this class can handle the scheme name. 
 	Part of the extension mechanism for new ressource reference types"
 	^ false
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MicResourceReference class >> newFromUri: uri [
 	"Default implementation"
 	^ self new uri: uri; yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicResourceReference >> fullName [
 	"Returns the full name of the resources (without microdown arguments) i.e, http://pharo.org/community/foo.png"
 	
 	^ self uriString 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicResourceReference >> isDirectory [ 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicResourceReference >> isRelative [
 	^ false
 ]

--- a/src/Microdown/MicResourceReferenceError.class.st
+++ b/src/Microdown/MicResourceReferenceError.class.st
@@ -5,7 +5,9 @@ I am signalled when one tries to access a resource which can not be accessed for
 In particular, the methods `loadImage` and `loadMicrodown` in (subclasses of) `MicAbsoluteResourceReference` can signal me.
 "
 Class {
-	#name : #MicResourceReferenceError,
-	#superclass : #Error,
-	#category : #'Microdown-Core'
+	#name : 'MicResourceReferenceError',
+	#superclass : 'Error',
+	#category : 'Microdown-Core',
+	#package : 'Microdown',
+	#tag : 'Core'
 }

--- a/src/Microdown/MicRootBlock.class.st
+++ b/src/Microdown/MicRootBlock.class.st
@@ -2,17 +2,19 @@
 I am the root of the github markup tree
 "
 Class {
-	#name : #MicRootBlock,
-	#superclass : #MicAbstractBlock,
-	#category : #'Microdown-Model'
+	#name : 'MicRootBlock',
+	#superclass : 'MicAbstractBlock',
+	#category : 'Microdown-Model',
+	#package : 'Microdown',
+	#tag : 'Model'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicRootBlock >> accept: aVisitor [
  	^ aVisitor visitRoot: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicRootBlock >> addLineAndReturnNextNode: line [
 	"add line to this node. 
 	Notice, the action is allowed to create new nodes in the block tree.
@@ -23,19 +25,19 @@ MicRootBlock >> addLineAndReturnNextNode: line [
 	^ newBlock 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicRootBlock >> canConsumeLine: line [
 	"The root block can always consume everything no matter what it is."
 
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicRootBlock >> indent [
 	^0
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicRootBlock >> properties: aConfigurationForPillar [
 	"Pay attention the strong hypothesis here is that keys of microdown properties and pillar configuration should not overlap. A possible solution would be to have clever at: and at:put: that check for example for a prefix for microdown properties.
 	

--- a/src/Microdown/MicSameStartStopMarkupBlock.class.st
+++ b/src/Microdown/MicSameStartStopMarkupBlock.class.st
@@ -8,42 +8,44 @@ endMarkup
 My subclass should define lineMarkup
 "
 Class {
-	#name : #MicSameStartStopMarkupBlock,
-	#superclass : #MicStartStopMarkupBlock,
+	#name : 'MicSameStartStopMarkupBlock',
+	#superclass : 'MicStartStopMarkupBlock',
 	#instVars : [
 		'arguments'
 	],
-	#category : #'Microdown-Model'
+	#category : 'Microdown-Model',
+	#package : 'Microdown',
+	#tag : 'Model'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicSameStartStopMarkupBlock class >> isAbstract [
 
 	^ self == MicSameStartStopMarkupBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicSameStartStopMarkupBlock >> arguments [
 	^ arguments
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicSameStartStopMarkupBlock >> caption [
 	self deprecated: 'Should only be used for test' transformWith: '`@rec caption' -> '`@rec testCaptionString'.
 	^ self testCaptionString.
 ]
 
-{ #category : #'accessing-delegated' }
+{ #category : 'accessing-delegated' }
 MicSameStartStopMarkupBlock >> caption: aString [
 	arguments at: #caption put: (self inlineParse: aString)
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicSameStartStopMarkupBlock >> captionElements [
 	^ arguments at: #caption ifAbsent: [ #() ]
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 MicSameStartStopMarkupBlock >> closeMe [
 	"The only case where the receiver contains a nested element is in its caption"
 	
@@ -55,18 +57,18 @@ MicSameStartStopMarkupBlock >> closeMe [
 		arguments at: #caption put: (self inlineParse: cp) ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicSameStartStopMarkupBlock >> hasCaption [
 	^ arguments includesKey:  #caption
 ]
 
-{ #category : #markups }
+{ #category : 'markups' }
 MicSameStartStopMarkupBlock >> lineStopMarkup [
 
 	^ self lineStartMarkup
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicSameStartStopMarkupBlock >> testCaptionString [
 
 	^ (self arguments at: #caption ifAbsent: [ ^'No Caption' ]) printString

--- a/src/Microdown/MicScriptBlock.class.st
+++ b/src/Microdown/MicScriptBlock.class.st
@@ -7,17 +7,19 @@ A script extension should
 - or building a microdown tree at parse time using closeMe
 "
 Class {
-	#name : #MicScriptBlock,
-	#superclass : #MicAbstractCodeBlock,
-	#category : #'Microdown-Model'
+	#name : 'MicScriptBlock',
+	#superclass : 'MicAbstractCodeBlock',
+	#category : 'Microdown-Model',
+	#package : 'Microdown',
+	#tag : 'Model'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicScriptBlock >> accept: aVisitor [
 	aVisitor visitScript: self 
 ]
 
-{ #category : #handle }
+{ #category : 'handle' }
 MicScriptBlock >> extractFirstLineFrom: aLine [
 	"script=Pharo&label=fig1&caption=La vie est belle"
 	"The first tag is script type, its value is Pharo."

--- a/src/Microdown/MicSingleLineBlock.class.st
+++ b/src/Microdown/MicSingleLineBlock.class.st
@@ -3,19 +3,21 @@ I characterize one liners.
 They do not know consumeLine: beacuse they are composed of only one line. 
 "
 Class {
-	#name : #MicSingleLineBlock,
-	#superclass : #MicAbstractBlock,
-	#category : #'Microdown-Model'
+	#name : 'MicSingleLineBlock',
+	#superclass : 'MicAbstractBlock',
+	#category : 'Microdown-Model',
+	#package : 'Microdown',
+	#tag : 'Model'
 }
 
-{ #category : #public }
+{ #category : 'public' }
 MicSingleLineBlock >> addLineAndReturnNextNode: line [
 	"By default skip the rest of the line."
 
 	^ self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicSingleLineBlock >> canConsumeLine: line [
 	"return if this block can consume line"
 	

--- a/src/Microdown/MicSlideBlock.class.st
+++ b/src/Microdown/MicSlideBlock.class.st
@@ -12,35 +12,37 @@ to have the same slide but on two different layouts and not emit both.
 ```
 "
 Class {
-	#name : #MicSlideBlock,
-	#superclass : #MicEnvironmentBlock,
-	#category : #'Microdown-Extensions'
+	#name : 'MicSlideBlock',
+	#superclass : 'MicEnvironmentBlock',
+	#category : 'Microdown-Extensions',
+	#package : 'Microdown',
+	#tag : 'Extensions'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicSlideBlock class >> tag [
 
 	^ #slide
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicSlideBlock >> accept: aVisitor [
 	^ aVisitor visitSlide: self
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MicSlideBlock >> printOn: aStream [
 
 	super printOn: aStream.
 	aStream nextPutAll: ' -- ' ; nextPutAll: self title
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicSlideBlock >> tag [
 	^ arguments at: 'tag' ifAbsent: [ '' ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicSlideBlock >> title [
 	^ arguments at: 'title' ifAbsent: [ '' ]
 ]

--- a/src/Microdown/MicSourceBlock.class.st
+++ b/src/Microdown/MicSourceBlock.class.st
@@ -9,22 +9,24 @@ Yielding:
 The `side` argument can be `instance` or `class`. If can be omitted, and is then assumed to be `instance`
 "
 Class {
-	#name : #MicSourceBlock,
-	#superclass : #MicEnvironmentBlock,
-	#category : #'Microdown-Extensions'
+	#name : 'MicSourceBlock',
+	#superclass : 'MicEnvironmentBlock',
+	#category : 'Microdown-Extensions',
+	#package : 'Microdown',
+	#tag : 'Extensions'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicSourceBlock class >> tag [
 	^#source
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicSourceBlock >> accept: aVisitor [
 	aVisitor visitAll: self children 
 ]
 
-{ #category : #'parse support' }
+{ #category : 'parse support' }
 MicSourceBlock >> closeMe [
 	|builder|
 	super closeMe.
@@ -33,7 +35,7 @@ MicSourceBlock >> closeMe [
 	self children:  (Microdown parse: builder contents) children.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicSourceBlock >> sourceCode [
 
 	| className class methodName method|

--- a/src/Microdown/MicStartStopMarkupBlock.class.st
+++ b/src/Microdown/MicStartStopMarkupBlock.class.st
@@ -2,23 +2,25 @@
 May be in the future we will be able to say that SameMarkup is the same as a StartStop with the same delimiter but for now we do not know. 
 "
 Class {
-	#name : #MicStartStopMarkupBlock,
-	#superclass : #MicAbstractBlock,
+	#name : 'MicStartStopMarkupBlock',
+	#superclass : 'MicAbstractBlock',
 	#instVars : [
 		'isClosed',
 		'body',
 		'firstLine'
 	],
-	#category : #'Microdown-Model'
+	#category : 'Microdown-Model',
+	#package : 'Microdown',
+	#tag : 'Model'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicStartStopMarkupBlock class >> isAbstract [
 
 	^ self == MicStartStopMarkupBlock
 ]
 
-{ #category : #handle }
+{ #category : 'handle' }
 MicStartStopMarkupBlock >> addLineAndReturnNextNode: line [
 	"add line to this node. 
 	Notice, the action is allowed to create new nodes in the block tree.
@@ -33,17 +35,17 @@ MicStartStopMarkupBlock >> addLineAndReturnNextNode: line [
 	^ self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicStartStopMarkupBlock >> body [
 	^ body
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicStartStopMarkupBlock >> body: anObject [
 	body := anObject
 ]
 
-{ #category : #handle }
+{ #category : 'handle' }
 MicStartStopMarkupBlock >> bodyFromLine: line [
 	self flag: #todo. 
 	"I do not think that this is a good idea to use a string to represent lines.
@@ -52,7 +54,7 @@ MicStartStopMarkupBlock >> bodyFromLine: line [
 	body := body ifNil: [ line ] ifNotNil: [ body , String cr , line ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicStartStopMarkupBlock >> canConsumeLine: line [
 	"As soon as a line closes a code block, it does not accept anymore any line.
 	Indeed imagine 
@@ -71,7 +73,7 @@ MicStartStopMarkupBlock >> canConsumeLine: line [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicStartStopMarkupBlock >> doesLineStartWithMarkup: line [
 	"return if the line starts with a markup"
 
@@ -79,46 +81,46 @@ MicStartStopMarkupBlock >> doesLineStartWithMarkup: line [
 	
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicStartStopMarkupBlock >> doesLineStartWithStopMarkup: line [
 
 	"return if the line starts with a stop markup"
 	^ line beginsWith: self lineStopMarkup
 ]
 
-{ #category : #handle }
+{ #category : 'handle' }
 MicStartStopMarkupBlock >> extractFirstLineFrom: line [
 	^ line copyFrom: self lineStartMarkup size + 1 to: line size
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicStartStopMarkupBlock >> firstLine [
 	^ firstLine
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicStartStopMarkupBlock >> firstLine: anObject [
 	firstLine := anObject
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MicStartStopMarkupBlock >> initialize [
 	super initialize. 
 	isClosed := false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicStartStopMarkupBlock >> isClosed [
 	^ isClosed		
 ]
 
-{ #category : #markups }
+{ #category : 'markups' }
 MicStartStopMarkupBlock >> lineStartMarkup [
 
 	^ self subclassResponsibility 
 ]
 
-{ #category : #markups }
+{ #category : 'markups' }
 MicStartStopMarkupBlock >> lineStopMarkup [
 
 	^ self subclassResponsibility 

--- a/src/Microdown/MicStrikeFormatBlock.class.st
+++ b/src/Microdown/MicStrikeFormatBlock.class.st
@@ -2,24 +2,26 @@
 I represent a strike text section. I'm delimited using `~` as in `~strike~` to obtain ~strike~.
 "
 Class {
-	#name : #MicStrikeFormatBlock,
-	#superclass : #MicEvaluatedBlock,
-	#category : #'Microdown-InlineParser'
+	#name : 'MicStrikeFormatBlock',
+	#superclass : 'MicEvaluatedBlock',
+	#category : 'Microdown-InlineParser',
+	#package : 'Microdown',
+	#tag : 'InlineParser'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicStrikeFormatBlock class >> closingDelimiter [
 
  	^ StrikeMarkup
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicStrikeFormatBlock class >> openingDelimiter [
 
  	^ StrikeMarkup
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicStrikeFormatBlock >> accept: aVisitor [
 	^ aVisitor visitStrike: self
 ]

--- a/src/Microdown/MicTableBlock.class.st
+++ b/src/Microdown/MicTableBlock.class.st
@@ -34,21 +34,23 @@ No support for \|
 
 "
 Class {
-	#name : #MicTableBlock,
-	#superclass : #MicContinuousMarkedBlock,
+	#name : 'MicTableBlock',
+	#superclass : 'MicContinuousMarkedBlock',
 	#instVars : [
 		'rows',
 		'hasHeader'
 	],
-	#category : #'Microdown-Model'
+	#category : 'Microdown-Model',
+	#package : 'Microdown',
+	#tag : 'Model'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicTableBlock >> accept: aVisitor [
 	^ aVisitor visitTable: self
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MicTableBlock >> addLineAndReturnNextNode: line [
 	"line is assumed to be of the form 'chararacters some text' e.g., '> some text'
 	the prefix spaces after $> are removed"
@@ -59,7 +61,7 @@ MicTableBlock >> addLineAndReturnNextNode: line [
 	
 ]
 
-{ #category : #'parse support' }
+{ #category : 'parse support' }
 MicTableBlock >> closeMe [ 
 
 	| firstSize |
@@ -69,13 +71,13 @@ MicTableBlock >> closeMe [
 		        each collect: [ :e | self inlineParse: e ] ].
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MicTableBlock >> cut: row toSize: firstSize [
 
 	^ row copyFrom: 1 to: ( row size min: firstSize)
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MicTableBlock >> extractLine: line [
 	"recondition line starts with |
 	
@@ -95,19 +97,19 @@ MicTableBlock >> extractLine: line [
 		
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicTableBlock >> hasHeader [
 	^ hasHeader
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MicTableBlock >> initialize [ 
 	super initialize.
 	rows := OrderedCollection new.
 	hasHeader := false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicTableBlock >> isHeader: line [
 	"Return true whether a line is a table header identification i.e., | --- | --- |"
 	
@@ -117,13 +119,13 @@ MicTableBlock >> isHeader: line [
 	
 ]
 
-{ #category : #markups }
+{ #category : 'markups' }
 MicTableBlock >> lineMarkup [
 
 	^ TableCellMarkup
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicTableBlock >> rows [
 	^ rows
 ]

--- a/src/Microdown/MicTextBlock.class.st
+++ b/src/Microdown/MicTextBlock.class.st
@@ -2,31 +2,33 @@
 I'm a special inline block representing the fact that there is not markup. 
 "
 Class {
-	#name : #MicTextBlock,
-	#superclass : #MicUnEvaluatedBlock,
-	#category : #'Microdown-InlineParser'
+	#name : 'MicTextBlock',
+	#superclass : 'MicUnEvaluatedBlock',
+	#category : 'Microdown-InlineParser',
+	#package : 'Microdown',
+	#tag : 'InlineParser'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicTextBlock >> accept: aVisitor [
 	^ aVisitor visitText: self
 ]
 
-{ #category : #obsolete }
+{ #category : 'obsolete' }
 MicTextBlock >> substring [
 	"Should only be used for tests"
 	self deprecated: 'Just use bodystring' transformWith: '`@rec substring' -> '`@rec bodystring'.
 	^ bodystring 
 ]
 
-{ #category : #obsolete }
+{ #category : 'obsolete' }
 MicTextBlock >> substring: aBody [
 	"Should only be used for tests"
 	self deprecated: 'Just use bodystring:' transformWith: '`@rec substring: `@arg' -> '`@rec bodystring: `@arg'.
 	^ bodystring 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicTextBlock >> text [
 	^ bodystring 
 ]

--- a/src/Microdown/MicUnEvaluatedBlock.class.st
+++ b/src/Microdown/MicUnEvaluatedBlock.class.st
@@ -2,59 +2,61 @@
 I represent blocks whose contents is not microdown markup as such.
 "
 Class {
-	#name : #MicUnEvaluatedBlock,
-	#superclass : #MicInlineElement,
+	#name : 'MicUnEvaluatedBlock',
+	#superclass : 'MicInlineElement',
 	#instVars : [
 		'bodystring'
 	],
-	#category : #'Microdown-InlineParser'
+	#category : 'Microdown-InlineParser',
+	#package : 'Microdown',
+	#tag : 'InlineParser'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicUnEvaluatedBlock class >> isEvaluated [
 	^ false
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 MicUnEvaluatedBlock class >> parse: delimiter stream: aTokenStream for: aParser [
 	^ aParser parseNonEvaluatedBlock: self token: delimiter stream: aTokenStream
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicUnEvaluatedBlock >> bodystring [
 
 	^ bodystring
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicUnEvaluatedBlock >> bodystring: anObject [
 
 	bodystring := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicUnEvaluatedBlock >> children [
 	"to be nicely polymorphic all nodes have children"
 	^#()
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicUnEvaluatedBlock >> children: newChildren [
 	"to be nicely polymorphic all nodes have children"
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MicUnEvaluatedBlock >> plainText [
 	^ bodystring 
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MicUnEvaluatedBlock >> printOn: stream [
 	stream << self blockName << '(' << bodystring << ')'
 	
 ]
 
-{ #category : #obsolete }
+{ #category : 'obsolete' }
 MicUnEvaluatedBlock >> substring [
 	self flag: 'to be obsoleted, use bodystring'.
 	^ bodystring

--- a/src/Microdown/MicUnknownResourceUri.class.st
+++ b/src/Microdown/MicUnknownResourceUri.class.st
@@ -2,12 +2,14 @@
 I am used for representing unknow uri rferences, for example `foo://bar.baz/path`
 "
 Class {
-	#name : #MicUnknownResourceUri,
-	#superclass : #MicAbsoluteResourceReference,
-	#category : #'Microdown-Core'
+	#name : 'MicUnknownResourceUri',
+	#superclass : 'MicAbsoluteResourceReference',
+	#category : 'Microdown-Core',
+	#package : 'Microdown',
+	#tag : 'Core'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicUnknownResourceUri >> binaryReadStream [
 	"Return an image with my contents (an error message)"
 	| file |
@@ -16,7 +18,7 @@ MicUnknownResourceUri >> binaryReadStream [
 	^ file binaryReadStream 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicUnknownResourceUri >> contents [
 	"Just return an error message"
 	^'No resource type for `', self uriString ,'`'

--- a/src/Microdown/MicUnorderedListBlock.class.st
+++ b/src/Microdown/MicUnorderedListBlock.class.st
@@ -44,17 +44,19 @@ It produces
 
 "
 Class {
-	#name : #MicUnorderedListBlock,
-	#superclass : #MicListBlock,
-	#category : #'Microdown-Model'
+	#name : 'MicUnorderedListBlock',
+	#superclass : 'MicListBlock',
+	#category : 'Microdown-Model',
+	#package : 'Microdown',
+	#tag : 'Model'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicUnorderedListBlock >> accept: aVisitor [
  	^ aVisitor visitUnorderedList: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicUnorderedListBlock >> canConsumeLine: line [
 	"to consume this line there must be a UnorderdListItem start at the right indentation"
 

--- a/src/Microdown/MicZincPathResolver.class.st
+++ b/src/Microdown/MicZincPathResolver.class.st
@@ -16,15 +16,17 @@ If the base is a file based reference with an explicit filesystem (see comment i
 When parsing a resource reference (image, link or inputfile) which is relative, instances of `MicRelativeResourceReferences` are created in the parse nodes for `MicFigureBlock`, `MicLinkBlock` or `MicInputfileBlock`. I will replace all relative references in those blocks with absolute references based on the rfc3986 algorithm mentioned above.
 "
 Class {
-	#name : #MicZincPathResolver,
-	#superclass : #MicrodownVisitor,
+	#name : 'MicZincPathResolver',
+	#superclass : 'MicrodownVisitor',
 	#instVars : [
 		'absoluteReference'
 	],
-	#category : #'Microdown-Core'
+	#category : 'Microdown-Core',
+	#package : 'Microdown',
+	#tag : 'Core'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MicZincPathResolver class >> resolve: document withBase: aRef [
 	"Assumes aRef to be a MicAbsoluteRessourceReference. 
 	Converts all relative references to absolute references in document"
@@ -34,19 +36,19 @@ MicZincPathResolver class >> resolve: document withBase: aRef [
 		
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicZincPathResolver >> absoluteReference: aReferenceOrString [
 	absoluteReference := aReferenceOrString isString
 		ifTrue: [ MicResourceReference fromUri: aReferenceOrString ]
 		ifFalse: [ aReferenceOrString ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicZincPathResolver >> resolveDocument: document [
 	self visit: document
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MicZincPathResolver >> resolveReferenceIn: aNode [
 	"currently links, figures and input nodes need to be resolved"
 	| resolvedUri resolvedReference |
@@ -57,18 +59,18 @@ MicZincPathResolver >> resolveReferenceIn: aNode [
 	aNode reference: resolvedReference
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicZincPathResolver >> visitFigure: aFigure [
 
 	self resolveReferenceIn: aFigure
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicZincPathResolver >> visitInputFile: anInputFile [
 	self resolveReferenceIn: anInputFile 
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicZincPathResolver >> visitLink: aLink [
 	self resolveReferenceIn: aLink
 ]

--- a/src/Microdown/MicroSharedPool.class.st
+++ b/src/Microdown/MicroSharedPool.class.st
@@ -1,5 +1,7 @@
 Class {
-	#name : #MicroSharedPool,
-	#superclass : #MicMicrodownSharedPool,
-	#category : #'Microdown-Parser'
+	#name : 'MicroSharedPool',
+	#superclass : 'MicMicrodownSharedPool',
+	#category : 'Microdown-Parser',
+	#package : 'Microdown',
+	#tag : 'Parser'
 }

--- a/src/Microdown/Microdown.class.st
+++ b/src/Microdown/Microdown.class.st
@@ -7,16 +7,18 @@ In particular I invoke a resolver for paths after parsing documents .
 <!inputFile|path=pharo:///Microdown/facadeMethods!>
 "
 Class {
-	#name : #Microdown,
-	#superclass : #Object,
+	#name : 'Microdown',
+	#superclass : 'Object',
 	#classVars : [
 		'IsCachingResources',
 		'Offline'
 	],
-	#category : #'Microdown-Core'
+	#category : 'Microdown-Core',
+	#package : 'Microdown',
+	#tag : 'Core'
 }
 
-{ #category : #facade }
+{ #category : 'facade' }
 Microdown class >> asRichText: aStringOrDoc [
 	"Facade method to render a microdown document or string to Text"
 	^ MicRichTextComposer asRichText: aStringOrDoc.
@@ -24,12 +26,12 @@ Microdown class >> asRichText: aStringOrDoc [
 	
 ]
 
-{ #category : #facade }
+{ #category : 'facade' }
 Microdown class >> builder [
 	^ MicrodownParser builder
 ]
 
-{ #category : #facade }
+{ #category : 'facade' }
 Microdown class >> facadeMethods [
 	| facadeMethods aBuilder |
 	facadeMethods := self methodsInProtocol: 'facade'.
@@ -45,14 +47,14 @@ Microdown class >> facadeMethods [
 	
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 Microdown class >> isCachingResources [
 	IsCachingResources ifNil: [ IsCachingResources := true ].
 
 	^ IsCachingResources 
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 Microdown class >> isCachingResources: aBoolean [
 
 	IsCachingResources := aBoolean.
@@ -62,12 +64,12 @@ Microdown class >> isCachingResources: aBoolean [
 	aBoolean ifFalse: [ MicHTTPResourceReference resetResourcesCache ]
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 Microdown class >> isCachingResourcesDocForSetting [
 	^ 'When we refer to an HTTP resources, use a  cache it instead of systematically refetch it.'
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 Microdown class >> microdownPreferenceSettingsOn: aBuilder [
 	<systemsettings>
 	(aBuilder group: #microdownAndcomments)
@@ -88,34 +90,34 @@ Microdown class >> microdownPreferenceSettingsOn: aBuilder [
 			]
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 Microdown class >> offline [
 	Offline ifNil: [ Offline := false ].
 	^ Offline
 
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 Microdown class >> offline: aBoolean [
 
 	Offline := aBoolean
 
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 Microdown class >> offlineDocForSetting [
 	^ 'When online is chosen, requests to external images are only performed when they are not in the image cache (since requesting systematically HTTP may lead of latency. Each figure is cached, so the request is at most done one per external references. When the system is online but the request failed we return a placeholder that is not cached.
 			
 			When offline, requests to external images are not performed. The cache can be reset executing PRRichTextComposer resetCache. When the system is off line and an image is requested, a placeholder is computed but not put in the cache. This way when the system is put online the requested elements will be requested and put in the cache (without needing to flush placeholders from the cache).'
 ]
 
-{ #category : #facade }
+{ #category : 'facade' }
 Microdown class >> parse: aStreamOrString [
 
 	^ self new parse: aStreamOrString
 ]
 
-{ #category : #facade }
+{ #category : 'facade' }
 Microdown class >> resolveDocument: document withBase: base [
 	"resolve all relative urls in document with respect to the absolute uri 
 	base can be a aString | aZnUrl | absoluteResourceReference"
@@ -123,7 +125,7 @@ Microdown class >> resolveDocument: document withBase: base [
 	^ document 
 ]
 
-{ #category : #facade }
+{ #category : 'facade' }
 Microdown class >> resolveString: markup withBase: uri [
 	"resolve all relative urls in document with respect to the absolute uri (aString|aZnUrl|absoluteResourceReference)"
 	| doc |
@@ -132,26 +134,26 @@ Microdown class >> resolveString: markup withBase: uri [
 	^ doc
 ]
 
-{ #category : #facade }
+{ #category : 'facade' }
 Microdown >> builder [
 
 	^ self class builder
 ]
 
-{ #category : #facade }
+{ #category : 'facade' }
 Microdown >> parse: aStreamOrString [
 
 	^ MicrodownParser parse: aStreamOrString
 ]
 
-{ #category : #facade }
+{ #category : 'facade' }
 Microdown >> render: aStringOrDoc [
 	"Facade method to render a microdown string to Text"
 	^ self class render: aStringOrDoc 
 	
 ]
 
-{ #category : #facade }
+{ #category : 'facade' }
 Microdown >> resolveDocument: document withBase: base [
 	"resolve all relative urls in document with respect to the absolute uri 
 	base can be a aString | aZnUrl | absoluteResourceReference"

--- a/src/Microdown/MicrodownParser.class.st
+++ b/src/Microdown/MicrodownParser.class.st
@@ -154,8 +154,8 @@ Now the implementation for now does not create a paragraph in the list_item elem
 
 "
 Class {
-	#name : #MicrodownParser,
-	#superclass : #Object,
+	#name : 'MicrodownParser',
+	#superclass : 'Object',
 	#instVars : [
 		'current',
 		'root',
@@ -164,27 +164,29 @@ Class {
 	#pools : [
 		'MicMicrodownSharedPool'
 	],
-	#category : #'Microdown-Parser'
+	#category : 'Microdown-Parser',
+	#package : 'Microdown',
+	#tag : 'Parser'
 }
 
-{ #category : #builder }
+{ #category : 'builder' }
 MicrodownParser class >> builder [
 	^ MicMicrodownTextualBuilder new
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 MicrodownParser class >> example [
 	<sampleInstance>
 	^ self parse: self comment
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MicrodownParser class >> parse: aString [
 
 	^ self new parse: aString
 ]
 
-{ #category : #'node creation' }
+{ #category : 'node creation' }
 MicrodownParser >> blockStarterClassFrom: line [
 	"return the class of a block which can start with line, or nil if none"
 
@@ -205,26 +207,26 @@ MicrodownParser >> blockStarterClassFrom: line [
 	^ self nonMatchedBlockClassFor: line
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicrodownParser >> builder [
 	"return a little helper to build microdown correct expression"
 	
 	^ self class builder
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicrodownParser >> current [ 
 
 	^ current
 ]
 
-{ #category : #'node creation' }
+{ #category : 'node creation' }
 MicrodownParser >> delimiterBlockClassFor: prefix [
 
 	^ self paragraphBlockClass
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 MicrodownParser >> handleLine: line [
 
 	"The logic is the following: 
@@ -240,7 +242,7 @@ MicrodownParser >> handleLine: line [
 	self handleLine: line
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MicrodownParser >> initialize [
 
 	super initialize.
@@ -261,48 +263,48 @@ MicrodownParser >> initialize [
 	dispatchTable at: TableCellMarkup put: MicTableBlock.
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MicrodownParser >> isAList: normalized [
 	
 	^ (self matchUnordered: normalized) or: [ self matchOrdered: normalized ]
 ]
 
-{ #category : #'node creation' }
+{ #category : 'node creation' }
 MicrodownParser >> matchOrdered: line [
 	^ line prefixMatchesRegex: '\d+(\.|\))'
 ]
 
-{ #category : #'node creation' }
+{ #category : 'node creation' }
 MicrodownParser >> matchUnordered: line [
 	^ ( line beginsWith: UnorderedListPlusMarkup ) 
 		| ( line beginsWith: UnorderedListStarMarkup ) 
 		| ( line beginsWith: UnorderedListMarkup )
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 MicrodownParser >> newRootBlock [
 	^ MicRootBlock new
 ]
 
-{ #category : #'node creation' }
+{ #category : 'node creation' }
 MicrodownParser >> nonMatchedBlockClassFor: line [
 
 	^ self paragraphBlockClass
 ]
 
-{ #category : #'node creation' }
+{ #category : 'node creation' }
 MicrodownParser >> orderedListBlockClass [
 
 	^ MicOrderedListBlock
 ]
 
-{ #category : #'node creation' }
+{ #category : 'node creation' }
 MicrodownParser >> paragraphBlockClass [
 
 	^ MicParagraphBlock
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 MicrodownParser >> parse: aStreamOrString [
 	"returns the root node of aStreamOrText"
 
@@ -325,7 +327,7 @@ MicrodownParser >> parse: aStreamOrString [
 	^ root
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MicrodownParser >> setCurrent: aBlock [
 	"aBlock parent = current 
 		ifFalse: [ self error: 'When changing current, the current block should be the parent of the new one' ].

--- a/src/Microdown/MicrodownVisitor.class.st
+++ b/src/Microdown/MicrodownVisitor.class.st
@@ -6,260 +6,262 @@ of MicElement.
 
 "
 Class {
-	#name : #MicrodownVisitor,
-	#superclass : #Object,
-	#category : #'Microdown-Visitor'
+	#name : 'MicrodownVisitor',
+	#superclass : 'Object',
+	#category : 'Microdown-Visitor',
+	#package : 'Microdown',
+	#tag : 'Visitor'
 }
 
-{ #category : #'visiting main API' }
+{ #category : 'visiting main API' }
 MicrodownVisitor >> visit: aMicElement [
 
 	^ aMicElement accept: self
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicrodownVisitor >> visitAgenda: anAgenda [
 	"subclassResponsibility"
 ]
 
-{ #category : #'visiting main API' }
+{ #category : 'visiting main API' }
 MicrodownVisitor >> visitAll: aCollection [
 
 	^ aCollection collect: [ :each | each accept: self ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicrodownVisitor >> visitAnchor: anAnchor [
 ]
 
-{ #category : #'visiting - inline elements' }
+{ #category : 'visiting - inline elements' }
 MicrodownVisitor >> visitAnchorReference: anAnchorReference [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicrodownVisitor >> visitAnnotated: anAnnotated [
 
 	^ anAnnotated body do: [ :each | each accept: self ]
 ]
 
-{ #category : #'visiting - inline elements' }
+{ #category : 'visiting - inline elements' }
 MicrodownVisitor >> visitAnnotation: anAnnotation [
 ]
 
-{ #category : #'visiting - inline elements' }
+{ #category : 'visiting - inline elements' }
 MicrodownVisitor >> visitBold: aFormat [
 
 	^ self visitChildrenOf: aFormat.
 
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicrodownVisitor >> visitBreak: aBreak [
 	"subclassResponsibility"
 ]
 
-{ #category : #'visiting - inline elements' }
+{ #category : 'visiting - inline elements' }
 MicrodownVisitor >> visitChildrenOf: anElement [
 
 	^ anElement children collect: [ :each | each accept: self ]
 ]
 
-{ #category : #'visiting - extensions' }
+{ #category : 'visiting - extensions' }
 MicrodownVisitor >> visitCitation: aVisitor [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicrodownVisitor >> visitCode: aCodeBlock [ 
 	 
 	^ aCodeBlock captionElements collect: [ :each |each accept: self ]
 
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicrodownVisitor >> visitColumn: aColumn [
 	^ self visitEnvironment: aColumn
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicrodownVisitor >> visitColumns: aColumns [
 	^ self visitEnvironment: aColumns
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicrodownVisitor >> visitComment: aComment [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicrodownVisitor >> visitDay: aDay [
 	"subclassResponsibility"
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicrodownVisitor >> visitEnvironment: anEnvironment [
 
 	^ anEnvironment bodyElements do: [ :each | each accept: self ]
 ]
 
-{ #category : #'visiting - inline elements' }
+{ #category : 'visiting - inline elements' }
 MicrodownVisitor >> visitFigure: aFigure [
 
 	^ aFigure children do: [ :each | each accept: self ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicrodownVisitor >> visitFootnote: aFootnote [
 	"subclassResponsibility"
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicrodownVisitor >> visitHeader: aHeader [
 
 	^  aHeader headerElements do: [ :each | each accept: self ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicrodownVisitor >> visitHorizontalLine: anHorizontalLineBlock [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicrodownVisitor >> visitInputFile: anInputfile [
 	"subclassResponsibility"
 ]
 
-{ #category : #'visiting - inline elements' }
+{ #category : 'visiting - inline elements' }
 MicrodownVisitor >> visitItalic: aFormat [
 
 	^ self visitChildrenOf: aFormat.
 
 ]
 
-{ #category : #'visiting - inline elements' }
+{ #category : 'visiting - inline elements' }
 MicrodownVisitor >> visitLink: aLink [
 
 	^ aLink children do: [ :each | each accept: self ]
 ]
 
-{ #category : #'visiting - list' }
+{ #category : 'visiting - list' }
 MicrodownVisitor >> visitListItem: anItem [
 
 	^ self visitChildrenOf: anItem
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicrodownVisitor >> visitMath: aMicMath [
 
 	^ aMicMath captionElements collect: [ :each | each accept: self ]
 
 ]
 
-{ #category : #'visiting - inline elements' }
+{ #category : 'visiting - inline elements' }
 MicrodownVisitor >> visitMathInline: aMicMathInline [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicrodownVisitor >> visitMetaData: aMetaData [
 ]
 
-{ #category : #'visiting - inline elements' }
+{ #category : 'visiting - inline elements' }
 MicrodownVisitor >> visitMonospace: aFormat [
 
 	^ self visitChildrenOf: aFormat.
 
 ]
 
-{ #category : #'visiting - list' }
+{ #category : 'visiting - list' }
 MicrodownVisitor >> visitOrderedList: anOrderedList [
 
 	^ anOrderedList children collect: [ :each | self visitOrderedListItem: each ]
 ]
 
-{ #category : #'visiting - list' }
+{ #category : 'visiting - list' }
 MicrodownVisitor >> visitOrderedListItem: anItem [
 
 	^ self visitListItem: anItem
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicrodownVisitor >> visitParagraph: aParagraph [
 	
 	^ self visitChildrenOf: aParagraph
 ]
 
-{ #category : #'visiting - extensions' }
+{ #category : 'visiting - extensions' }
 MicrodownVisitor >> visitPharoEvaluator: aScriptBlock [
 
 	self visitScript: aScriptBlock
 ]
 
-{ #category : #'visiting - extensions' }
+{ #category : 'visiting - extensions' }
 MicrodownVisitor >> visitPharoScript: aPharoScriptNode [
 	^ self visitScript: aPharoScriptNode 
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicrodownVisitor >> visitQuote: aQuote [
 	^ self visitChildrenOf: aQuote
 ]
 
-{ #category : #'visiting - inline elements' }
+{ #category : 'visiting - inline elements' }
 MicrodownVisitor >> visitRaw: aRawFormat [
 
 	
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicrodownVisitor >> visitRoot: aRoot [
 
 	^ self visitChildrenOf: aRoot
 ]
 
-{ #category : #'visiting - extensions' }
+{ #category : 'visiting - extensions' }
 MicrodownVisitor >> visitScript: aSlide [
 
 	^ aSlide children collect: [ :each | self visit: each ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicrodownVisitor >> visitSegment: aSegment [
 	"subclassResponsibility"
 ]
 
-{ #category : #'visiting - extensions' }
+{ #category : 'visiting - extensions' }
 MicrodownVisitor >> visitSlide: aSlide [
 
 	^ aSlide children collect: [ :each | self visit: each ]
 ]
 
-{ #category : #'visiting - inline elements' }
+{ #category : 'visiting - inline elements' }
 MicrodownVisitor >> visitStrike: aFormat [
 
 	^ self visitChildrenOf: aFormat.
 
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicrodownVisitor >> visitTable: aTable [
 	"subclassResponsibility"
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MicrodownVisitor >> visitTalk: aTalk [
 	"subclassResponsibility"
 ]
 
-{ #category : #'visiting - inline elements' }
+{ #category : 'visiting - inline elements' }
 MicrodownVisitor >> visitText: aMicTextBlock [
 
 	"do nothing"
 ]
 
-{ #category : #'visiting - list' }
+{ #category : 'visiting - list' }
 MicrodownVisitor >> visitUnorderedList: anUnorderedList [
 
 	^ anUnorderedList children collect: [ :each | self visitUnorderedListItem: each ]
 ]
 
-{ #category : #'visiting - list' }
+{ #category : 'visiting - list' }
 MicrodownVisitor >> visitUnorderedListItem: anUnorderedList [
 
 	^ self visitListItem: anUnorderedList

--- a/src/Microdown/OrderedDictionary.extension.st
+++ b/src/Microdown/OrderedDictionary.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #OrderedDictionary }
+Extension { #name : 'OrderedDictionary' }
 
-{ #category : #'*Microdown' }
+{ #category : '*Microdown' }
 OrderedDictionary >> at: key add: value [
 	"Store value under key. If key already exists, store multiple values as Array"
 	

--- a/src/Microdown/Package.extension.st
+++ b/src/Microdown/Package.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : 'Package' }
+
+{ #category : '*Microdown' }
+Package >> buildMicroDownUsing: aMicMicrodownTextualBuilder withComment: aString [ 
+
+	aMicMicrodownTextualBuilder
+		header: [ 
+			aMicMicrodownTextualBuilder text: 'Class: '.
+			aMicMicrodownTextualBuilder text: self name ] withLevel: 1;
+		horizontalLine;
+		text: aString
+]

--- a/src/Microdown/RGBehavior.extension.st
+++ b/src/Microdown/RGBehavior.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #RGBehavior }
+Extension { #name : 'RGBehavior' }
 
-{ #category : #'*Microdown' }
+{ #category : '*Microdown' }
 RGBehavior >> buildMicroDownUsing: aMicMicrodownTextualBuilder withComment: aString [
 
 	aMicMicrodownTextualBuilder

--- a/src/Microdown/RGPackage.extension.st
+++ b/src/Microdown/RGPackage.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #RGPackage }
+Extension { #name : 'RGPackage' }
 
-{ #category : #'*Microdown' }
+{ #category : '*Microdown' }
 RGPackage >> buildMicroDownUsing: aMicMicrodownTextualBuilder withComment: aString [
 
 	aMicMicrodownTextualBuilder

--- a/src/Microdown/RPackage.extension.st
+++ b/src/Microdown/RPackage.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #RPackage }
+Extension { #name : 'RPackage' }
 
-{ #category : #'*Microdown' }
+{ #category : '*Microdown' }
 RPackage >> buildMicroDownUsing: aBuilder withComment: aString [
 	
 	"I'm on a package and the package is a baseline package."

--- a/src/Microdown/SequenceableCollection.extension.st
+++ b/src/Microdown/SequenceableCollection.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #SequenceableCollection }
+Extension { #name : 'SequenceableCollection' }
 
-{ #category : #'*Microdown' }
+{ #category : '*Microdown' }
 SequenceableCollection >> splitOnFirst: char [
 	| indexOfChar |
 	indexOfChar := self indexOf: char.

--- a/src/Microdown/String.extension.st
+++ b/src/Microdown/String.extension.st
@@ -1,11 +1,11 @@
-Extension { #name : #String }
+Extension { #name : 'String' }
 
-{ #category : #'*Microdown' }
+{ #category : '*Microdown' }
 String >> asMicResourceReference [
 	^ MicResourceReference fromUri: self
 ]
 
-{ #category : #'*Microdown' }
+{ #category : '*Microdown' }
 String >> escapeAll [
 	| escaped |
 	escaped := String new: self size * 2.
@@ -15,12 +15,12 @@ String >> escapeAll [
 	^ escaped
 ]
 
-{ #category : #'*Microdown' }
+{ #category : '*Microdown' }
 String >> resolveDocument: document [
 	^ self asMicResourceReference resolveDocument: document.
 ]
 
-{ #category : #'*Microdown' }
+{ #category : '*Microdown' }
 String >> stripNtabs: n [
 	"remove up to N tabs from the beginning"
 	| count max |
@@ -31,7 +31,7 @@ String >> stripNtabs: n [
 	^ self allButFirst: count-1
 ]
 
-{ #category : #'*Microdown' }
+{ #category : '*Microdown' }
 String >> withoutPreTabs [
 	"return a copy of me, without tabs in the begining "
 	^ self trimLeft: [ :char | char = Character tab ]

--- a/src/Microdown/TestCase.extension.st
+++ b/src/Microdown/TestCase.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #TestCase }
+Extension { #name : 'TestCase' }
 
-{ #category : #'*Microdown' }
+{ #category : '*Microdown' }
 TestCase class >> buildMicroDownUsing: aBuilder withComment: aString [
 	
 	| number |

--- a/src/Microdown/Text.extension.st
+++ b/src/Microdown/Text.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Text }
+Extension { #name : 'Text' }
 
-{ #category : #'*Microdown' }
+{ #category : '*Microdown' }
 Text >> attributeAt: idx ofKind: aClass [
 	(self attributesAt: idx)
 			detect: [ :attr | attr isKindOf: aClass  ] 

--- a/src/Microdown/ZnUrl.extension.st
+++ b/src/Microdown/ZnUrl.extension.st
@@ -1,11 +1,11 @@
-Extension { #name : #ZnUrl }
+Extension { #name : 'ZnUrl' }
 
-{ #category : #'*Microdown' }
+{ #category : '*Microdown' }
 ZnUrl >> asMicResourceReference [
 	^ MicResourceReference fromUri: self
 ]
 
-{ #category : #'*Microdown' }
+{ #category : '*Microdown' }
 ZnUrl >> resolveDocument: document [
 	^ self asMicResourceReference resolveDocument: document.
 ]

--- a/src/Microdown/package.st
+++ b/src/Microdown/package.st
@@ -1,1 +1,1 @@
-Package { #name : #Microdown }
+Package { #name : 'Microdown' }


### PR DESCRIPTION
Reported in https://github.com/pharo-project/pharo/issues/15916

This PR just add to Pharo 12 a method for rendering package comments, which was lost from Pharo 11.
