### PR TITLE
Move extension to renamed Package

### DIFF
--- a/src/Microdown/Package.extension.st
+++ b/src/Microdown/Package.extension.st
@@ -1,7 +1,7 @@
-Extension { #name : 'RPackage' }
+Extension { #name : 'Package' }
 
 { #category : '*Microdown' }
-RPackage >> buildMicroDownUsing: aBuilder withComment: aString [
+Package >> buildMicroDownUsing: aBuilder withComment: aString [
 	
 	"I'm on a package and the package is a baseline package."
 	self class environment


### PR DESCRIPTION
RPackage was renamed Package in Pharo 12. Fix extension method