### PR TITLE
Fix parsing of links

### DIFF
--- a/src/Microdown-LaTeXExporter/MicLaTeXWriter.class.st
+++ b/src/Microdown-LaTeXExporter/MicLaTeXWriter.class.st
@@ -231,7 +231,6 @@ MicLaTeXWriter >> visitItalic: anItalic [
 MicLaTeXWriter >> visitLink: aLink [
 
 	| reference |
-	self halt.
 	reference := aLink fileStringWithoutHostFile.
 
 	canvas command

--- a/src/Microdown-Tests/MicLinkBlockTest.class.st
+++ b/src/Microdown-Tests/MicLinkBlockTest.class.st
@@ -155,26 +155,22 @@ MicLinkBlockTest >> testPrintOn [
 
 { #category : 'tests' }
 MicLinkBlockTest >> testTwoUrls [
+
 	| lk |
-	self skip.
 	lk := (MicInlineParser new parse: '[https://advanced-design-mooc.pharo.org](https://advanced-design-mooc.pharo.org)') first.
-	
+
 	self assert: lk bodyString equals: 'https://advanced-design-mooc.pharo.org'.
 	self assert: lk url equals: 'https://advanced-design-mooc.pharo.org'
-	
-	
 ]
 
 { #category : 'tests' }
 MicLinkBlockTest >> testTwoUrlsWithMicrodownParser [
+
 	| lk |
-	self skip.
 	lk := (parser parse: '[https://advanced-design-mooc.pharo.org](https://advanced-design-mooc.pharo.org)') children first children first.
-	
+
 	self assert: lk bodyString equals: 'https://advanced-design-mooc.pharo.org'.
 	self assert: lk url equals: 'https://advanced-design-mooc.pharo.org'
-	
-	
 ]
 
 { #category : 'tests' }

--- a/src/Microdown/MicInlineHttpDelimiter.class.st
+++ b/src/Microdown/MicInlineHttpDelimiter.class.st
@@ -44,5 +44,7 @@ MicInlineHttpDelimiter >> markup [
 
 { #category : 'accessing' }
 MicInlineHttpDelimiter >> markupAsRegex [
-	^ 'http(s)?\://[\S]+' 
+	"We end the link if we find a character that is a whitespace OR a $]. $] should be valid in links but it causes conflicts with the closing bracket of the body of link syntax with the way microdown is coded. Thus, this is a hack to limit the impact of this conflict. We prefer to be able to parse things such as: `[http://mylink.fr](http://mylink.fr)` than matching links containing a $]. "
+
+	^ 'http(s)?\://[^]\s]+'
 ]

--- a/src/Microdown/MicInlineParser.class.st
+++ b/src/Microdown/MicInlineParser.class.st
@@ -98,18 +98,15 @@ MicInlineParser >> parseEvaluatedBlock: blockType token: token stream: tokenStre
 { #category : 'private parsing' }
 MicInlineParser >> parseNameUrlBlock: blockType from: aTokenStream token: token [
 
-	| skipRes children urlToken|
-	skipRes := (self skipToUrlStartInStream: aTokenStream).
-	skipRes ifNil: [ ^ self createTextBlock: token string].
+	| skipRes children urlToken |
+	skipRes := self skipToUrlStartInStream: aTokenStream.
+	skipRes ifNil: [ ^ self createTextBlock: token string ].
 	children := self parseChildrenIn: skipRes second.
 	urlToken := aTokenStream next.
 	^ blockType new
-		children: children;
-		url: urlToken undelimitedSubstring;
-		closeMe.
-		
-	
-
+		  children: children;
+		  url: urlToken undelimitedSubstring;
+		  closeMe
 ]
 
 { #category : 'private parsing' }


### PR DESCRIPTION
Update the link regex to not conflict with the syntax of MicLinkBlock `[]()`.

Fixes #699