### PR TITLE
Backport "Make monospace text readable again" to P12

### DIFF
--- a/src/Microdown-RichTextComposer/MicTextStyler.class.st
+++ b/src/Microdown-RichTextComposer/MicTextStyler.class.st
@@ -80,7 +80,8 @@ MicTextStyler >> interBlockSpacing [
 
 { #category : 'composer styles' }
 MicTextStyler >> monospaceBackgroundColor [
-	^ Smalltalk ui theme settings windowColor
+
+	^ Color transparent alpha: 0.01
 ]
 
 { #category : 'canvas styles' }

--- a/src/Microdown-RichTextComposer/MicrodownParser.extension.st
+++ b/src/Microdown-RichTextComposer/MicrodownParser.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : 'MicrodownParser' }
 
 { #category : '*Microdown-RichTextComposer' }
-MicrodownParser classSide >> convertToRichText: aString [
+MicrodownParser class >> convertToRichText: aString [
 	^ MicRichTextComposer new visit: (self new parse: aString)
 ]


### PR DESCRIPTION
See https://github.com/pillar-markup/Microdown/pull/701