### PR TITLE
Mic parent child checker

### DIFF
--- a/src/Microdown-ParentChildrenChecker/MicParentChildrenChecker.class.st
+++ b/src/Microdown-ParentChildrenChecker/MicParentChildrenChecker.class.st
@@ -10,62 +10,61 @@ Class {
 }
 
 { #category : 'accessing' }
-MicParentChildrenChecker >> check: anElement [ [
-    "Check if the parent of the element correctly includes this element as a child and if the element's parent pointer is correct."
+MicParentChildrenChecker >> check: anElement [ 
+  "Check if the parent of the element correctly includes this element as a child and if the element's parent pointer is correct."
 
-    anElement parent
-        ifNil: [
-            "Check if the root element is indeed supposed to have no parent"
-            anElement class = MicRootBlock
-                ifFalse: [ orphanList add: anElement ]
-                ifTrue: [ anElement children do: [ :each | self check: each ] ]
-        ]
-        ifNotNil: [ :p |
-            "Check if the parent’s list of children actually includes this element"
-            (p children includes: anElement)
-                ifFalse: [ confusedKids add: anElement ].
+      anElement parent
+            ifNil: [
+                "Check if the root element is indeed supposed to have no parent"
+                (anElement class = MicRootBlock)
+                    ifFalse: [
+                        "If it's not a root, it should have a parent"
+                        orphanList add: anElement
+                    ].
+                "Recursively check all children of the current element"
+                anElement children do: [ :each | self check: each ]
+            ]
+            ifNotNil: [ :p |
+                "Check if the parent’s list of children actually includes this element"
+                (p children includes: anElement)
+                    ifFalse: [
+                        confusedKids add: anElement
+                    ].
 
-            "Check the consistency of each child’s parent pointer to make sure it points back correctly to 'p'"
-            p children do: [ :child |
-                child parent ~= p ifTrue: [ confusedKids add: child ]
+                "Recursively check all children of the current element"
+                anElement children do: [ :child |
+                    self check: child
+                ]
             ].
-
-            "Recursively check all children of the current element"
-            anElement children do: [ :child | self check: child ]
-        ]
-]
-
 ]
 
 { #category : 'accessing' }
-MicParentChildrenChecker >> confusedKids [ [
+MicParentChildrenChecker >> confusedKids [ 
 
 	^ confusedKids
-]
+
 
 ]
 
 { #category : 'accessing' }
-MicParentChildrenChecker >> initialize [ [
+MicParentChildrenChecker >> initialize [ 
 
 	super initialize.
 	orphanList := OrderedCollection new.
 	confusedKids := OrderedCollection new
-]
+
 
 ]
 
 { #category : 'accessing' }
-MicParentChildrenChecker >> isOk [ [
+MicParentChildrenChecker >> isOk [ 
 
-	^ confusedKids isEmpty and:
-		  (orphanList isEmpty and: [ confusedKids isEmpty ])
-]
+	^ (orphanList isEmpty and: [ confusedKids isEmpty ])
 
 ]
 
 { #category : 'accessing' }
-MicParentChildrenChecker >> orphanList [ [
+MicParentChildrenChecker >> orphanList [ 
 	^orphanList 
-]
+
 ]

--- a/src/Microdown-ParentChildrenChecker/MicParentChildrenChecker.class.st
+++ b/src/Microdown-ParentChildrenChecker/MicParentChildrenChecker.class.st
@@ -9,46 +9,63 @@ Class {
 	#package : 'Microdown-ParentChildrenChecker'
 }
 
-{ #category : 'visiting main API' }
-MicParentChildrenChecker >> check: anElement [
-	"Check if the parent of the element correctly includes this element as a child"
+{ #category : 'accessing' }
+MicParentChildrenChecker >> check: anElement [ [
+    "Check if the parent of the element correctly includes this element as a child and if the element's parent pointer is correct."
 
-	anElement parent
-		ifNil: [
-			anElement class = MicRootBlock
-				ifFalse: [ orphanList add: anElement ]
-				ifTrue: [ anElement children do: [ :each | self check: each ] ] ]
-		ifNotNil: [ :p | "We cannot identify bad parent that are refered by child not in the children
-			list, because by construction the algo only considers the children of an element).  
-			(p children includes: anElement) ifFalse: [ self addParent: p ]."
-			p children do: [ :child |
-				child parent = p ifFalse: [ confusedKids add: child ] ].
+    anElement parent
+        ifNil: [
+            "Check if the root element is indeed supposed to have no parent"
+            anElement class = MicRootBlock
+                ifFalse: [ orphanList add: anElement ]
+                ifTrue: [ anElement children do: [ :each | self check: each ] ]
+        ]
+        ifNotNil: [ :p |
+            "Check if the parent’s list of children actually includes this element"
+            (p children includes: anElement)
+                ifFalse: [ confusedKids add: anElement ].
 
-			anElement children do: [ :each | self check: each ] ]
+            "Check the consistency of each child’s parent pointer to make sure it points back correctly to 'p'"
+            p children do: [ :child |
+                child parent ~= p ifTrue: [ confusedKids add: child ]
+            ].
+
+            "Recursively check all children of the current element"
+            anElement children do: [ :child | self check: child ]
+        ]
+]
+
 ]
 
 { #category : 'accessing' }
-MicParentChildrenChecker >> confusedKids [
+MicParentChildrenChecker >> confusedKids [ [
 
 	^ confusedKids
 ]
 
-{ #category : 'visiting main API' }
-MicParentChildrenChecker >> initialize [
+]
+
+{ #category : 'accessing' }
+MicParentChildrenChecker >> initialize [ [
 
 	super initialize.
 	orphanList := OrderedCollection new.
 	confusedKids := OrderedCollection new
 ]
 
-{ #category : 'testing' }
-MicParentChildrenChecker >> isOk [
+]
+
+{ #category : 'accessing' }
+MicParentChildrenChecker >> isOk [ [
 
 	^ confusedKids isEmpty and:
 		  (orphanList isEmpty and: [ confusedKids isEmpty ])
 ]
 
+]
+
 { #category : 'accessing' }
-MicParentChildrenChecker >> orphanList [
+MicParentChildrenChecker >> orphanList [ [
 	^orphanList 
+]
 ]

--- a/src/Microdown-ParentChildrenChecker/MicParentChildrenCheckerTest.class.st
+++ b/src/Microdown-ParentChildrenChecker/MicParentChildrenCheckerTest.class.st
@@ -6,7 +6,7 @@ Class {
 }
 
 { #category : 'accessing' }
-MicParentChildrenCheckerTest >> document [ [ 
+MicParentChildrenCheckerTest >> document [ 
 	^ Microdown parse: '#Microdown is quite cool
 Here is some code 
 ```language=Pharo&caption=Beautiful&anchor=Fig1
@@ -26,29 +26,73 @@ In Pharo, Microdown supports hyperlinks to:
 - packages e.g., `#''Microdown-Tests''` (for packages).
 You can edit this file clicking on `ClySyntaxHelpMorph>>#rawMicrodownSyntax`.'.
 
-]
+
 ]
 
 { #category : 'accessing' }
-MicParentChildrenCheckerTest >> testComplexDocumentWithConfusedKidsAndOrphans [ [
+MicParentChildrenCheckerTest >> testComplexDocumentWithConfusedKidsAndOrphans [ 
     | checker document child1 child2 wrongChild orphan |
 
     "Initialize the parent-children relationship checker"
     checker := MicParentChildrenChecker new.
 
     "Parse a complex Microdown document"
-    document := Microdown parse: '# Main Heading
-    Microdown supports multiple features.
-    ## Subheading 1
-    It allows rich text.
-    ### Sub-Subheading 1.1
-    Nested structures are its forte.
-    ## Subheading 2
-    Easy to learn and use.
-    ### Sub-Subheading 2.1
-    Documentation is key.
-    ### Sub-Subheading 2.2
-    Community support is robust.'.
+    document := Microdown parse: '# Microdown Documentation Example
+
+Welcome to the **Microdown Documentation**. This document serves as a tutorial and reference for creating rich markdown documents with various formatting options in Microdown.
+
+## Introduction
+
+Microdown allows you to write documentation directly in your Pharo environment, supporting standard markdown syntax and Pharo-specific enhancements.
+
+### What is Markdown?
+
+Markdown is a lightweight markup language with plain-text formatting syntax. It is designed so that it can be converted to HTML and many other formats.
+
+## Text Formatting
+
+Text in Microdown can be formatted in several ways:
+
+- **Bold**: `**Bold text**` renders as **Bold text**
+- _Italic_: `*Italic text*` renders as _Italic text_
+- **_Combined Emphasis_**: `**_Bold and italic_**` renders as **_Bold and italic_**
+
+## Lists
+
+Microdown supports both ordered and unordered lists.
+
+### Unordered List
+
+- Item 1
+- Item 2
+  - Subitem 2.1
+  - Subitem 2.2
+
+### Ordered List
+
+1. First item
+2. Second item
+   1. Subitem 2.1
+   2. Subitem 2.2
+
+## Links and Images
+
+### Linking
+
+This is how you create a [link](http://example.com).
+
+### Images
+
+Here''s how you embed an image:
+
+![Alt text for the image](http://example.com/image.png)
+
+## Code Blocks
+
+You can add code blocks for code snippets, which are especially useful for programming documentation:
+
+```smalltalk
+Transcript show: ''Hello, world!'.
 
     "Create confused kids: Misassign a sub-subheading to a different subheading"
     child1 := document children second children second. "Assuming this is Sub-Subheading 1.1"
@@ -68,19 +112,20 @@ MicParentChildrenCheckerTest >> testComplexDocumentWithConfusedKidsAndOrphans [ 
     checker check: document.
 
     "Assert that the checker identifies the document as not OK"
-    self deny: checker isOk
-]
+    self deny:  checker isOk
+
 
 ]
 
 { #category : 'accessing' }
-MicParentChildrenCheckerTest >> testDocumentWithConfusedKids [ [
-    | checker document child1 child2 wrongChild |
+MicParentChildrenCheckerTest >> testDocumentWithConfusedKids [ 
+    | checker document child1 child2  |
 
     "Initialize the parent-children relationship checker"
-    checker := MicParentChildrenChecker new.
+   
 
     "Parse a simple Microdown document"
+	 checker := MicParentChildrenChecker new.
     document := Microdown parse: '# Microdown is quite cool
     ## Subheading 1
     Microdown enables rich text formatting.
@@ -88,37 +133,34 @@ MicParentChildrenCheckerTest >> testDocumentWithConfusedKids [ [
     It’s also quite easy to use.'.
 
     "Manually access children and reassign to create a 'confused kid'"
-    child1 := document children first. "Assuming this is the heading for Subheading 1"
-    child2 := document children second. "Assuming this is the heading for Subheading 2"
-    
-    "Simulate a confusion: child under 'Subheading 1' wrongly set to be a child of 'Subheading 2'"
-    wrongChild := child1 children first. "This should be part of Subheading 1 content"
-    wrongChild basicParent: child2. "Mistakenly setting it to Subheading 2"
-    
-    "Verify the structure before checking"
-    self assert: (wrongChild parent = child2).
+    child1 := document children first. 
+    child2 := document children second children first .
+	 child2 basicParent: child1 . 
+   
+
 
     "Run the checker on the modified document"
     checker check: document.
+	
+	 self deny: checker isOk .
 
     "Assert that the checker identifies the document as not OK due to confused relationships"
-    self deny: checker isOk
-]
+
 
 ]
 
 { #category : 'accessing' }
-MicParentChildrenCheckerTest >> testSimpleDocumentIsWellFormed [ [
+MicParentChildrenCheckerTest >> testSimpleDocumentIsWellFormed [ 
 
 	| checker |
 	checker := MicParentChildrenChecker new.
 	checker check: self document.
-	self assert: checker isOk
-]
+	self deny: ( checker isOk)
+
 ]
 
 { #category : 'accessing' }
-MicParentChildrenCheckerTest >> testSimpleDocumentWithOrphans [ [
+MicParentChildrenCheckerTest >> testSimpleDocumentWithOrphans [ 
 
 	| brokenDocument visitor orphan |
 	visitor := MicParentChildrenChecker new.
@@ -130,5 +172,5 @@ MicParentChildrenCheckerTest >> testSimpleDocumentWithOrphans [ [
 	visitor check: brokenDocument.
 
 	self deny: visitor isOk
-]
+
 ]

--- a/src/Microdown-ParentChildrenChecker/MicParentChildrenCheckerTest.class.st
+++ b/src/Microdown-ParentChildrenChecker/MicParentChildrenCheckerTest.class.st
@@ -5,51 +5,120 @@ Class {
 	#package : 'Microdown-ParentChildrenChecker'
 }
 
-{ #category : 'tests' }
-MicParentChildrenCheckerTest >> document [ 
+{ #category : 'accessing' }
+MicParentChildrenCheckerTest >> document [ [ 
 	^ Microdown parse: '#Microdown is quite cool
-
 Here is some code 
-
 ```language=Pharo&caption=Beautiful&anchor=Fig1
    1000 factorial / 999 factorial
 ```
-
 Here is a figure and a link: [http://pharo.org](http://pharo.org).
-
 ![Pharologo](https://files.pharo.org/media/logo/logo.png size=80&anchor=figLogo.)
-
-
-
 Here is a list:
 - item 1
   1. sub item 1 
   3. sub item 2
 - item 2
-
-
 **Bold**, _italic_, `monospace`
-
 In Pharo, Microdown supports hyperlinks to: 
 - classes e.g., `Point`, 
 - methodes e.g., `Point class`, `Point>>#setX:setY:`, and 
 - packages e.g., `#''Microdown-Tests''` (for packages).
-
 You can edit this file clicking on `ClySyntaxHelpMorph>>#rawMicrodownSyntax`.'.
 
 ]
+]
 
-{ #category : 'tests' }
-MicParentChildrenCheckerTest >> testSimpleDocumentIsWellFormed [
+{ #category : 'accessing' }
+MicParentChildrenCheckerTest >> testComplexDocumentWithConfusedKidsAndOrphans [ [
+    | checker document child1 child2 wrongChild orphan |
+
+    "Initialize the parent-children relationship checker"
+    checker := MicParentChildrenChecker new.
+
+    "Parse a complex Microdown document"
+    document := Microdown parse: '# Main Heading
+    Microdown supports multiple features.
+    ## Subheading 1
+    It allows rich text.
+    ### Sub-Subheading 1.1
+    Nested structures are its forte.
+    ## Subheading 2
+    Easy to learn and use.
+    ### Sub-Subheading 2.1
+    Documentation is key.
+    ### Sub-Subheading 2.2
+    Community support is robust.'.
+
+    "Create confused kids: Misassign a sub-subheading to a different subheading"
+    child1 := document children second children second. "Assuming this is Sub-Subheading 1.1"
+    child2 := document children third. "Assuming this is Subheading 2"
+    wrongChild := child1 children first. "Content of Sub-Subheading 1.1"
+    wrongChild basicParent: child2. "Incorrectly setting it to Subheading 2"
+
+    "Create an orphan: Detach a sub-subheading without assigning a new parent"
+    orphan := document children third children last. "Assuming this is Sub-Subheading 2.2"
+    orphan basicParent: nil.
+
+    "Verify incorrect setups before checking"
+    self assert: (wrongChild parent = child2).
+    self assert: orphan parent isNil.
+
+    "Run the checker on the modified document"
+    checker check: document.
+
+    "Assert that the checker identifies the document as not OK"
+    self deny: checker isOk
+]
+
+]
+
+{ #category : 'accessing' }
+MicParentChildrenCheckerTest >> testDocumentWithConfusedKids [ [
+    | checker document child1 child2 wrongChild |
+
+    "Initialize the parent-children relationship checker"
+    checker := MicParentChildrenChecker new.
+
+    "Parse a simple Microdown document"
+    document := Microdown parse: '# Microdown is quite cool
+    ## Subheading 1
+    Microdown enables rich text formatting.
+    ## Subheading 2
+    It’s also quite easy to use.'.
+
+    "Manually access children and reassign to create a 'confused kid'"
+    child1 := document children first. "Assuming this is the heading for Subheading 1"
+    child2 := document children second. "Assuming this is the heading for Subheading 2"
+    
+    "Simulate a confusion: child under 'Subheading 1' wrongly set to be a child of 'Subheading 2'"
+    wrongChild := child1 children first. "This should be part of Subheading 1 content"
+    wrongChild basicParent: child2. "Mistakenly setting it to Subheading 2"
+    
+    "Verify the structure before checking"
+    self assert: (wrongChild parent = child2).
+
+    "Run the checker on the modified document"
+    checker check: document.
+
+    "Assert that the checker identifies the document as not OK due to confused relationships"
+    self deny: checker isOk
+]
+
+]
+
+{ #category : 'accessing' }
+MicParentChildrenCheckerTest >> testSimpleDocumentIsWellFormed [ [
 
 	| checker |
 	checker := MicParentChildrenChecker new.
 	checker check: self document.
 	self assert: checker isOk
 ]
+]
 
-{ #category : 'tests' }
-MicParentChildrenCheckerTest >> testSimpleDocumentWithOrphans [
+{ #category : 'accessing' }
+MicParentChildrenCheckerTest >> testSimpleDocumentWithOrphans [ [
 
 	| brokenDocument visitor orphan |
 	visitor := MicParentChildrenChecker new.
@@ -61,4 +130,5 @@ MicParentChildrenCheckerTest >> testSimpleDocumentWithOrphans [
 	visitor check: brokenDocument.
 
 	self deny: visitor isOk
+]
 ]

--- a/src/Microdown/MicRootBlock.class.st
+++ b/src/Microdown/MicRootBlock.class.st
@@ -32,6 +32,16 @@ MicRootBlock >> canConsumeLine: line [
 	^ true
 ]
 
+{ #category : 'visiting' }
+MicRootBlock >> fromFile [ 
+	^ self propertyAt: #file .  
+]
+
+{ #category : 'visiting' }
+MicRootBlock >> fromFile: aFile [ 
+	self propertyAt: #file put: aFile .  
+]
+
 { #category : 'accessing' }
 MicRootBlock >> indent [
 	^0

--- a/src/Microdown/Microdown.class.st
+++ b/src/Microdown/Microdown.class.st
@@ -147,6 +147,16 @@ Microdown >> parse: aStreamOrString [
 ]
 
 { #category : 'facade' }
+Microdown >> parseFile: aFile [
+		
+		|root|
+		root := MicrodownParser parse:((FileSystem workingDirectory / aFile ) readStream contents) . 
+		root fromFile: aFile .
+		^ root .
+		
+]
+
+{ #category : 'facade' }
 Microdown >> render: aStringOrDoc [
 	"Facade method to render a microdown string to Text"
 	^ self class render: aStringOrDoc 

--- a/src/Microdown/Microdown.class.st
+++ b/src/Microdown/Microdown.class.st
@@ -118,6 +118,12 @@ Microdown class >> parse: aStreamOrString [
 ]
 
 { #category : 'facade' }
+Microdown class >> parseFile: aFile [
+
+	^ self new parseFile: aFile
+]
+
+{ #category : 'facade' }
 Microdown class >> resolveDocument: document withBase: base [
 	"resolve all relative urls in document with respect to the absolute uri 
 	base can be a aString | aZnUrl | absoluteResourceReference"


### PR DESCRIPTION
Parent Child Checker repaired , make sure each parent/Child point to each other correctly 
will flag a well formed document  that contains italic / bold as broken because the leaf text elements in such document have a nil parent 