### PR TITLE
Handle metadata parsing error

### DIFF
--- a/src/Microdown/MicMetaDataBlock.class.st
+++ b/src/Microdown/MicMetaDataBlock.class.st
@@ -46,7 +46,7 @@ MicMetaDataBlock >> bogusParsing [
 { #category : 'markups' }
 MicMetaDataBlock >> closeMe [ 
 	super closeMe.
-	body := [ STONJSON fromString: '{', body, '}' ] on: STONReaderError do: [ :ex |
+	body := [ STONJSON fromString: '{', body, '}' ] on: Error do: [ :ex |
 		| dict |
 		bogusParsing := true.
 		dict := Dictionary new at: self keyForUnparsableContents put: body; yourself ]


### PR DESCRIPTION
Fix #760: Handle all errors that may occur while parsing metadata, with the goal of always returning a MicMetaDataBlock.