### PR TITLE
Fix #762: avoid empty lines in nested lists

### DIFF
--- a/src/Microdown-RichTextComposer-Tests/MicRichTextComposerTest.class.st
+++ b/src/Microdown-RichTextComposer-Tests/MicRichTextComposerTest.class.st
@@ -486,7 +486,7 @@ MicRichTextComposerTest >> testNestedMixedList [
 ]
 
 { #category : 'skipped tests' }
-MicRichTextComposerTest >> testNestedMixedListNoEmptyLinesEfterSubLists [
+MicRichTextComposerTest >> testNestedMixedListNoEmptyLinesAfterSubLists [
 
 	| source output |
 	source := 
@@ -494,12 +494,10 @@ MicRichTextComposerTest >> testNestedMixedListNoEmptyLinesEfterSubLists [
   1. sub item 1.1
 - item 2
   2. sub item 2.1
-  2. sub item 2.2
+     - sub item 2.1.1
 - item 3'.
 	output := (self richTextForString: source) asString trim.
 	self assert: output lines size equals: 6
-	
-	
 ]
 
 { #category : 'skipped tests' }
@@ -543,7 +541,7 @@ And this is just an other paragraph'.
 ]
 
 { #category : 'tests - list' }
-MicRichTextComposerTest >> testNosuperfluousNewLines [
+MicRichTextComposerTest >> testNoSuperfluousNewLines [
 
 	| source richText expected |
 	source :=  'This is **bold**'.
@@ -582,6 +580,18 @@ MicRichTextComposerTest >> testOrderedNestedList [
 	self assert: (richText asString includesSubstring: 'A)	Second item').
 	self assert: (richText asString includesSubstring: 'a)	Third item')
 	
+]
+
+{ #category : 'tests' }
+MicRichTextComposerTest >> testOrderedNestedListNoEmptyLinesAfterSubLists [
+	| source output |
+	source := '
+1. First item
+   2. Second item
+      3. Third item
+4. Fourth item'.
+	output := (self richTextForString: source) asString trim.
+	self assert: output lines size equals: 4.
 ]
 
 { #category : 'tests - paragraph' }
@@ -684,6 +694,18 @@ MicRichTextComposerTest >> testUnorderedList [
 	self assert: runs first first amount equals: 1.
 	self assert: (runs at: 29) "the first o in 'on two lines'" first class equals: TextIndent.
 	self assert: (runs at: 29) first amount equals: 2.
+]
+
+{ #category : 'tests' }
+MicRichTextComposerTest >> testUnorderedNestedListNoEmptyLinesAfterSubLists [
+	| source output |
+	source := '
+- First item
+  - Second item
+    - Third item
+- Fourth item'.
+	output := (self richTextForString: source) asString trim.
+	self assert: output lines size equals: 4.
 ]
 
 { #category : 'tests - format' }

--- a/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
+++ b/src/Microdown-RichTextComposer/MicRichTextComposer.class.st
@@ -599,7 +599,7 @@ MicRichTextComposer >> visitOrderedList: aList [
 					put: (self textStyler counterFor: counter atLevel: self level).
 				counter := counter + 1 ].
 		super visitOrderedList: aList ].
-	canvas newLine.
+	canvas newLineIfNotAlready.
 	aList nestedLevel = 1 ifTrue: [ canvas << textStyler interBlockSpacing]
 ]
 
@@ -771,6 +771,6 @@ MicRichTextComposer >> visitUnorderedList: aList [
 						propertyAt: #bullet
 						put: (self textStyler bulletForLevel: self level) ].
 			super visitUnorderedList: aList ].
-	canvas newLine.
-	aList nestedLevel = 1 ifTrue: [ canvas << textStyler interBlockSpacing] 
+	canvas newLineIfNotAlready.
+	aList nestedLevel = 1 ifTrue: [ canvas << textStyler interBlockSpacing ]
 ]


### PR DESCRIPTION
Add tests and rename two tests that had a typo.