### PR TITLE
Microdown url references to web locations

### DIFF
--- a/src/Microdown/MicHTTPResourceReference.class.st
+++ b/src/Microdown/MicHTTPResourceReference.class.st
@@ -39,8 +39,7 @@ MicHTTPResourceReference class >> getBytesByHttp: uri [
 		get.
 		^ client entity bytes ] 
 	on: ZnHttpUnsuccessful, NetworkError, MessageNotUnderstood
-	do: [ :error | 
-			error resignalAs: (MicResourceReferenceError new messageText: 'Could not access ', uri printString)  ].
+	do: [ WebBrowser openOn: uri ].
 ]
 
 { #category : 'instance creation' }


### PR DESCRIPTION
Fix https://github.com/pharo-project/pharo/issues/16512
Now it always opens the web browser with the URL given, even if it's inaccessible.
Though, the user will only see that the URL is not working once the browser has loaded the page.
Correction of https://github.com/pillar-markup/Microdown/pull/759