### PR TITLE
issues 797 Parser handles better metadata broke blog tests 

### DIFF
--- a/src/Microdown-Blog-Tests/MicSingleSummarizerTest.class.st
+++ b/src/Microdown-Blog-Tests/MicSingleSummarizerTest.class.st
@@ -221,7 +221,7 @@ MicSingleSummarizerTest >> testWithFromFileNil [
 
 	micSingleSummarizer verifyFromFile: root.
 
-	self assert: root fromFile equals: ''
+	self assert: root fromFile equals: 'fakedFile'
 ]
 
 { #category : 'tests' }
@@ -265,14 +265,13 @@ MicSingleSummarizerTest >> testWithMetaDataButInvalidDate [
 MicSingleSummarizerTest >> testWithoutFromFile [
 
 	| root |
-	self skip. 
-	"should ask Quentin for help here."
+	
 	root := Microdown parse:
 		        resources generateFilesystemExample1 contents.
 
 	micSingleSummarizer verifyFromFile: root.
 
-	self assert: root fromFile equals: ''
+	self assert: root fromFile equals: 'fakedFile'
 ]
 
 { #category : 'tests' }

--- a/src/Microdown-Blog/MicSingleSummarizer.class.st
+++ b/src/Microdown-Blog/MicSingleSummarizer.class.st
@@ -139,7 +139,7 @@ MicSingleSummarizer >> verifyFromFile: aMicRootBlock [
 
 	| newFromFile |
 	
-	newFromFile := ''.
+	newFromFile := 'fakedFile'.
 
 	aMicRootBlock properties ifNotNil: [
 		aMicRootBlock properties ifNotEmpty: [


### PR DESCRIPTION
fix test for fromFile when the result is fakedFile when fromFile doesn't exist in metadata of the MicRootBlock