### PR TITLE
Add Blog packages to Extensions group in Baseline

### DIFF
--- a/src/BaselineOfMicrodown/BaselineOfMicrodown.class.st
+++ b/src/BaselineOfMicrodown/BaselineOfMicrodown.class.st
@@ -128,6 +128,8 @@ BaselineOfMicrodown >> baseline: spec [
 				#'Microdown-ParentChildrenChecker'
 				#'Microdown-BookTester'
 				#'Microdown-BookTester-Tests'
+				#'Microdown-Blog'
+				#'Microdown-Blog-Tests'
 				
 				);
 			group: 'All' with: #('Core' #'Microdown-BrowserExtensions' 'Tests' 'Extensions' 'Microdown-Pharo-Tools' 'RichText') ]


### PR DESCRIPTION
A small addition to include Microdown-Blog to the Extensions group in the Baseline.
