### PR TITLE
Fix unreadable code in Pharo Light theme

### DIFF
--- a/src/Microdown-RichTextComposer/MicSmalltalkTextStyler.class.st
+++ b/src/Microdown-RichTextComposer/MicSmalltalkTextStyler.class.st
@@ -17,6 +17,7 @@ MicSmalltalkTextStyler class >> initialize [
 	"do not super initialize, that whould interfer with settings"
 
 	styleTable := SHRBTextStyler styleTable. "Not super, as that would just refer to my class-side variables"
+	textAttributes := nil.
 	formatIncompleteIdentifiers := false
 ]
 


### PR DESCRIPTION
Fix an issue reported in https://github.com/pharo-project/pharo/issues/16876 that causes all Microdown Smalltalk code to be unreadable in the Calypso class comments and documentation browser.

Now Microdown code style follows the user's code style settings. This is done by resetting the textAttributes variable in the Microdown Smalltalk text styler during initialization, so it uses the user's configured code style.

<img width="1431" alt="Screenshot 2024-08-14 at 19 30 24" src="https://github.com/user-attachments/assets/28371f71-107c-4cea-bdec-3d0739eb4882">
