### PR TITLE
Port "Fix unreadable code in Pharo Light theme" to Pharo 13

### DIFF
--- a/src/Microdown-RichTextComposer/MicSmalltalkTextStyler.class.st
+++ b/src/Microdown-RichTextComposer/MicSmalltalkTextStyler.class.st
@@ -17,6 +17,7 @@ MicSmalltalkTextStyler class >> initialize [
 	"do not super initialize, that whould interfer with settings"
 
 	styleTable := SHRBTextStyler styleTable. "Not super, as that would just refer to my class-side variables"
+	textAttributes := nil.
 	formatIncompleteIdentifiers := false
 ]
 


### PR DESCRIPTION
This was merged in dev but is mostly useful for Pharo 13

https://github.com/pillar-markup/Microdown/pull/858