### PR TITLE
815 reference checker should handled the input files the same for the check dir than the check project

### DIFF
--- a/src/Microdown-BookTester-Tests/MicFileCollectorTest.class.st
+++ b/src/Microdown-BookTester-Tests/MicFileCollectorTest.class.st
@@ -161,7 +161,7 @@ MicFileCollectorTest >> testOnlyGoUpInFoldersStartingFromAnotherRoot [
 
 { #category : 'tests' }
 MicFileCollectorTest >> testUnreferencedFileAreNotHandled [
-	"This test verifies that the collector only collects files that are referenced from a root and not all the files in a folder."
+	"This test verifies that the collector only collects files that are referenced from a root and not all the files in a folder.    "
 
 	self createProjectWithUnreferencedFiles3And5.
 	self startVisitingFromTheRoot: section1.

--- a/src/Microdown-BookTester-Tests/MicFileTest.class.st
+++ b/src/Microdown-BookTester-Tests/MicFileTest.class.st
@@ -211,6 +211,17 @@ just text here
 ]
 
 { #category : 'helpers - only inputfiles' }
+MicFileTest >> section1IsLeafButContainsSomeUknownAnchors [
+
+	section1 := dir / 'section1.md'.
+	section1 ensureCreateFile.
+	section1 writeStreamDo: [ :stream |
+		stream nextPutAll: '# Section1
+here are some unknown anchors to prove that checkDirectory is working See *@anchorSection100@* and *@anchorSection200@* 
+' ]
+]
+
+{ #category : 'helpers - only inputfiles' }
 MicFileTest >> section2InputsNestedSection3 [
 
 	section2 := dir / 'sections/section2.md'.
@@ -339,6 +350,18 @@ MicFileTest >> section4InputsParentSection3 [
 	section4 writeStreamDo: [ :stream |
 		stream nextPutAll: '# section 4 
 <!inputFile|path=../section3.md!>
+' ]
+]
+
+{ #category : 'helpers - only inputfiles' }
+MicFileTest >> section4InputsParentSection3withUknownAnchors [
+
+	section4 := dir / 'sections/subsections/subsubsections/section4.md'.
+	section4 ensureCreateFile.
+	section4 writeStreamDo: [ :stream |
+		stream nextPutAll: '# section 4 
+<!inputFile|path=../section3.md!>
+here are some unknown anchors to prove that checkDirectory is working See *@anchorSection100@* and *@anchorSection200@* 
 ' ]
 ]
 

--- a/src/Microdown-BookTester-Tests/MicReferenceCheckerTest.class.st
+++ b/src/Microdown-BookTester-Tests/MicReferenceCheckerTest.class.st
@@ -434,11 +434,10 @@ Just a reference See *@ancS1@*  ' ].
 
 ]
 
-{ #category : 'skipped for now' }
+{ #category : 'tests - single file' }
 MicReferenceCheckerTest >> testDuplicatedAnchorDir [
 
-	| dir file1 file2 visitor   |
-	self skip.
+	|  file1 file2 visitor   |
 	dir := (FileSystem workingDirectory / 'myDirectory') asFileReference.
    dir ensureCreateDirectory.
 	
@@ -465,8 +464,8 @@ MicReferenceCheckerTest >> testDuplicatedAnchorDir [
    file2 ensureCreateFile . 
 
 	visitor := MicReferenceChecker new.
-
-	self deny: ( visitor checkDirectory: dir ) 
+   visitor checkDirectory: dir .
+	self deny: ( visitor isOkay ) 
 	
 ]
 
@@ -770,11 +769,10 @@ MicReferenceCheckerTest >> testReportingSTONFormatUnknownAnchorDir [
 	
 ]
 
-{ #category : 'skipped for now' }
+{ #category : 'tests - single file' }
 MicReferenceCheckerTest >> testReportingUnknownAnchorDir [
 
-	| dir file1 file2 visitor |
-	self skip.
+	|  file1 file2 visitor |
 	dir := (FileSystem workingDirectory / 'myDirectory') asFileReference.
    dir ensureCreateDirectory.
 	
@@ -794,8 +792,8 @@ MicReferenceCheckerTest >> testReportingUnknownAnchorDir [
    file2 ensureCreateFile. 
 
 	visitor := MicReferenceChecker new.
-
-	self deny: (visitor checkDirectory: dir).
+	visitor checkDirectory: dir .
+	self deny: (visitor isOkay ).
 	
 	file1 ensureDelete.
    file2 ensureDelete.

--- a/src/Microdown-BookTester/MicFileCollector.class.st
+++ b/src/Microdown-BookTester/MicFileCollector.class.st
@@ -16,19 +16,29 @@ Class {
 		'rootDirectory',
 		'visited',
 		'unexistingFiles',
-		'inputFiles'
+		'inputFiles',
+		'worklist'
 	],
 	#category : 'Microdown-BookTester',
 	#package : 'Microdown-BookTester'
 }
 
 { #category : 'visiting' }
+MicFileCollector >> add: aFile [
+	
+	worklist add: aFile .
+]
+
+{ #category : 'visiting' }
 MicFileCollector >> initialize [ 
 
 	super initialize.
 	rootDirectory := FileSystem workingDirectory.
+	worklist := OrderedCollection new.
 	visited := Set new.
 	unexistingFiles := Set new.
+
+
 ]
 
 { #category : 'accessing' }
@@ -58,8 +68,6 @@ MicFileCollector >> visitInputFile: anInputFile [
 { #category : 'visiting' }
 MicFileCollector >> visitRoot: micDocument [
 
-	| worklist |
-	worklist := OrderedCollection new.
 	worklist add: micDocument.
 
 	[ worklist isEmpty ] whileFalse: [
@@ -94,4 +102,10 @@ MicFileCollector >> visitRoot: micDocument [
 MicFileCollector >> visitedDocumentFiles [
 
 	^ visited
+]
+
+{ #category : 'visiting' }
+MicFileCollector >> workList [
+
+	^ worklist .
 ]

--- a/src/Microdown-BookTester/MicReferenceChecker.class.st
+++ b/src/Microdown-BookTester/MicReferenceChecker.class.st
@@ -92,7 +92,7 @@ MicReferenceChecker >> checkDirectory: aDir [
 	aDir allFiles do: [ :file | collector add: (Microdown parseFile: file ) ].
 	
 	collector
-		fileSystem: FileSystem memory ;
+		rootDirectory: FileSystem memory ;
 		visit: collector workList  first .
 	self handleUndefinedFilesFrom: collector.
 	listOfFiles := collector visitedDocumentFiles collect: [ :file |

--- a/src/Microdown-BookTester/MicReferenceChecker.class.st
+++ b/src/Microdown-BookTester/MicReferenceChecker.class.st
@@ -86,7 +86,18 @@ MicReferenceChecker >> buildReportSTONFormatOn: str [
 MicReferenceChecker >> checkDirectory: aDir [
 	"Take the directory, parse all its children with microdown file parser and let the visitor visit each time then return visitor is ok which should be true if every thing is okay, the visitor turned out to treat the many documents that it visits as one, so if anchor is duplicated in another file it will detect that . "
 	
-	self checkList: aDir allFiles
+	|  collector listOfFiles |
+	
+	collector := MicFileCollector new.
+	aDir allFiles do: [ :file | collector add: (Microdown parseFile: file ) ].
+	
+	collector
+		fileSystem: FileSystem memory ;
+		visit: collector workList  first .
+	self handleUndefinedFilesFrom: collector.
+	listOfFiles := collector visitedDocumentFiles collect: [ :file |
+		               (aDir fileSystem referenceTo: file)   ].	
+	self checkList: listOfFiles 
 ]
 
 { #category : 'internal' }

--- a/src/Microdown-BookTester/MicResult.class.st
+++ b/src/Microdown-BookTester/MicResult.class.st
@@ -37,6 +37,7 @@ MicResult class >> headerString [
 
 { #category : 'accessing' }
 MicResult >> explanation [
+"just test "
 
 	^ self subclassResponsibility
 ]


### PR DESCRIPTION
fix checkDirectory 