### PR TITLE
815 reference checker should handled the input files the same for the check dir than the check project

### DIFF
--- a/src/Microdown-BookTester-Tests/MicReferenceCheckerTest.class.st
+++ b/src/Microdown-BookTester-Tests/MicReferenceCheckerTest.class.st
@@ -424,11 +424,9 @@ Just a reference See *@ancS1@*  ' ].
 	file2 ensureCreateFile.
 
 	visitor := MicReferenceChecker new.
+	visitor rootDirectory: dir.
 	visitor checkDirectory: dir.
 	self assert: visitor isOkay
-	
-
-
 ]
 
 { #category : 'skipped for now' }
@@ -491,6 +489,7 @@ MicReferenceCheckerTest >> testDuplicatedAnchorInDifferentFilesOfTheSameDir [
 	file2 ensureCreateFile.
 
 	visitor := MicReferenceChecker new.
+	visitor rootDirectory: dir.
 	visitor checkDirectory: dir.
 	self deny: visitor isOkay.
 

--- a/src/Microdown-BookTester-Tests/MicReferenceCheckerTest.class.st
+++ b/src/Microdown-BookTester-Tests/MicReferenceCheckerTest.class.st
@@ -468,7 +468,7 @@ MicReferenceCheckerTest >> testDuplicatedAnchorDir [
 { #category : 'tests - directory api' }
 MicReferenceCheckerTest >> testDuplicatedAnchorInDifferentFilesOfTheSameDir [
 
-	| file1 file2 visitor dict original duplicated |
+	| file1 file2 visitor dict original duplicated resultFullName |
 	file1 := dir / 'file1.md'.
 	file1 writeStreamDo: [ :stream |
 		stream nextPutAll: '# Section 
@@ -498,18 +498,16 @@ MicReferenceCheckerTest >> testDuplicatedAnchorInDifferentFilesOfTheSameDir [
 		assert: visitor duplicatedAnchors first anchorLabel
 		equals: 'ancS1'.
 	dict := visitor results groupedBy: [ :each | each class ].
-	
+
 	original := (dict at: MicDuplicatedAnchorResult) first.
-	self
-		assert: visitor results first sourceFileReference fullName
-		equals: '/myDirectory/file1.md'.
 	self assert: original anchorLabel equals: 'ancS1'.
-	
+
 	duplicated := (dict at: MicDuplicatedAnchorResult) second.
-	self
-		assert: visitor results second sourceFileReference fullName
-		equals: '/myDirectory/file2.md'.
-	self assert: duplicated anchorLabel equals: 'ancS1'
+	self assert: duplicated anchorLabel equals: 'ancS1'.
+	
+resultFullName := visitor results collect: [ :each | each sourceFileReference fullName ].
+self
+		assert: (resultFullName includesAll: #('/myDirectory/file1.md' '/myDirectory/file2.md' ))
 ]
 
 { #category : 'tests - duplicated' }

--- a/src/Microdown-BookTester-Tests/MicReferenceCheckerTest.class.st
+++ b/src/Microdown-BookTester-Tests/MicReferenceCheckerTest.class.st
@@ -468,7 +468,7 @@ MicReferenceCheckerTest >> testDuplicatedAnchorDir [
 { #category : 'tests - directory api' }
 MicReferenceCheckerTest >> testDuplicatedAnchorInDifferentFilesOfTheSameDir [
 
-	| file1 file2 visitor dict duplicated |
+	| file1 file2 visitor dict original duplicated |
 	file1 := dir / 'file1.md'.
 	file1 writeStreamDo: [ :stream |
 		stream nextPutAll: '# Section 
@@ -498,9 +498,16 @@ MicReferenceCheckerTest >> testDuplicatedAnchorInDifferentFilesOfTheSameDir [
 		assert: visitor duplicatedAnchors first anchorLabel
 		equals: 'ancS1'.
 	dict := visitor results groupedBy: [ :each | each class ].
-	duplicated := (dict at: MicDuplicatedAnchorResult) first.
+	
+	original := (dict at: MicDuplicatedAnchorResult) first.
 	self
 		assert: visitor results first sourceFileReference fullName
+		equals: '/myDirectory/file1.md'.
+	self assert: original anchorLabel equals: 'ancS1'.
+	
+	duplicated := (dict at: MicDuplicatedAnchorResult) second.
+	self
+		assert: visitor results second sourceFileReference fullName
 		equals: '/myDirectory/file2.md'.
 	self assert: duplicated anchorLabel equals: 'ancS1'
 ]
@@ -530,19 +537,30 @@ MicReferenceCheckerTest >> testDuplicatedAnchors [
 { #category : 'tests - duplicated' }
 MicReferenceCheckerTest >> testDuplicatedAnchorsWithCheckListAndCheckDirectory [
 
-	| defAncS0TripleAncS1RefAncS1AncS0 checker1 checker2 |
+	| defAncS0TripleAncS1RefAncS1AncS0 checker1 checker2 dict1 dict2 |
 	defAncS0TripleAncS1RefAncS1AncS0 := self
 		                                    defAncS0TripleAncS1RefAncS1AncS0.
 	checker1 := MicReferenceChecker new.
-	checker1 checkList: { defAncS0TripleAncS1RefAncS1AncS0 }.
+	checker1 rootDirectory: dir.
+	checker1 checkProject: defAncS0TripleAncS1RefAncS1AncS0.
+
 	checker2 := MicReferenceChecker new.
+	checker2 rootDirectory: dir.
 	checker2 checkDirectory: dir.
+
 	self deny: checker1 isOkay.
 	self deny: checker2 isOkay.
 
 	self
-		assert: checker1 results
-		equals: checker2 results.
+		assert: (checker1 results collect: [ :each | each anchorLabel ])
+		equals: (checker2 results collect: [ :each | each anchorLabel ]).
+		
+	dict1 := checker1 results groupedBy: [ :each | each class ].
+	dict2 := checker2 results groupedBy: [ :each | each class ].
+	
+	self
+		assert: (dict1 at: MicDuplicatedAnchorResult) first sourceFileReference fullName
+		equals: (dict2 at: MicDuplicatedAnchorResult) first sourceFileReference fullName.
 ]
 
 { #category : 'tests - duplicated' }

--- a/src/Microdown-BookTester-Tests/MicReferenceCheckerTest.class.st
+++ b/src/Microdown-BookTester-Tests/MicReferenceCheckerTest.class.st
@@ -528,6 +528,24 @@ MicReferenceCheckerTest >> testDuplicatedAnchors [
 ]
 
 { #category : 'tests - duplicated' }
+MicReferenceCheckerTest >> testDuplicatedAnchorsWithCheckListAndCheckDirectory [
+
+	| defAncS0TripleAncS1RefAncS1AncS0 checker1 checker2 |
+	defAncS0TripleAncS1RefAncS1AncS0 := self
+		                                    defAncS0TripleAncS1RefAncS1AncS0.
+	checker1 := MicReferenceChecker new.
+	checker1 checkList: { defAncS0TripleAncS1RefAncS1AncS0 }.
+	checker2 := MicReferenceChecker new.
+	checker2 checkDirectory: dir.
+	self deny: checker1 isOkay.
+	self deny: checker2 isOkay.
+
+	self
+		assert: checker1 results
+		equals: checker2 results.
+]
+
+{ #category : 'tests - duplicated' }
 MicReferenceCheckerTest >> testDuplicatedBetweenSectionFigureEq [
 
 	| conflictBetweenFigSecEq visitor |

--- a/src/Microdown-BookTester/MicFileCollector.class.st
+++ b/src/Microdown-BookTester/MicFileCollector.class.st
@@ -68,6 +68,7 @@ MicFileCollector >> visitRoot: micDocument [
 	[ worklist isEmpty ] whileFalse: [
 		| currentDocument |
 		currentDocument := worklist removeFirst.
+		(visitedFiles includes: currentDocument) ifFalse: [ 
 		visitedFileStrings add: currentDocument fromFile fullName.
 		currentDocument resolveYourself.
 		visitedFiles add: currentDocument.
@@ -90,7 +91,7 @@ MicFileCollector >> visitRoot: micDocument [
 				doc := Microdown parseFile: fr.
 				worklist addFirst: doc ]
 					on: FileDoesNotExistException
-					do: [ unexistingFiles add: inputFile ] ] ] ]
+					do: [ unexistingFiles add: inputFile ] ] ] ]]
 ]
 
 { #category : 'accessing' }

--- a/src/Microdown-BookTester/MicReferenceChecker.class.st
+++ b/src/Microdown-BookTester/MicReferenceChecker.class.st
@@ -72,8 +72,21 @@ MicReferenceChecker >> addDuplicatedFirstAnchor: anAnchor [
 { #category : 'main API' }
 MicReferenceChecker >> checkDirectory: aDir [
 	"Take the directory, parse all its children with microdown file parser and let the visitor visit each time then return visitor is ok which should be true if every thing is okay, the visitor turned out to treat the many documents that it visits as one, so if anchor is duplicated in another file it will detect that . "
-	
-	self checkList: aDir allFiles
+
+	"self checkList: aDir allFiles"
+
+	| mainMic collector |
+	collector := MicFileCollector new.
+	collector rootDirectory: rootDirectory.
+
+	aDir allFiles do: [ :aFile |
+		mainMic := Microdown parseFile: aFile.
+		collector visit: mainMic ].
+
+	self handleUndefinedFilesFrom: collector.
+	listOfFiles := collector visitedFileStrings collect: [ :file |
+		               rootDirectory resolve: file ].
+	self checkList: listOfFiles
 ]
 
 { #category : 'internal' }
@@ -90,7 +103,7 @@ MicReferenceChecker >> checkList: aCollection [
 { #category : 'main API' }
 MicReferenceChecker >> checkProject: aFileReference [
 
-	| mainMic collector  |
+	| mainMic collector |
 	mainMic := Microdown parseFile: aFileReference.
 	collector := MicFileCollector new.
 	collector


### PR DESCRIPTION
Issue #815 
I change checkDirectory for using the same semantic as CheckProject
I also change visitRoot: of MicFileCollector for didn't visit a file already visited in the directory