### PR TITLE
Using new method extractInteger for parsing instead of asInteger

### DIFF
--- a/src/Microdown/MicOrderedListBlock.class.st
+++ b/src/Microdown/MicOrderedListBlock.class.st
@@ -69,5 +69,6 @@ MicOrderedListBlock >> startIndex [
 { #category : 'accessing' }
 MicOrderedListBlock >> startIndexFrom: line [
 	startIndex ifNotNil: [ ^self ].
-	startIndex := line asInteger
+	"an ordered list line starts with the index and after a dot '.' "
+	startIndex := line extractIntegerPart
 ]


### PR DESCRIPTION
Updated ordered list parsing with the method `extractIntegerPart` instead of `asInteger`. This PR requires the merging of https://github.com/pharo-project/pharo/pull/17299. 