### PR TITLE
Cleanup extensions

### DIFF
--- a/src/Microdown/MicAbstractBlock.class.st
+++ b/src/Microdown/MicAbstractBlock.class.st
@@ -113,6 +113,11 @@ MicAbstractBlock >> initialize [
 ]
 
 { #category : 'testing' }
+MicAbstractBlock >> isHeader [
+	^ false
+]
+
+{ #category : 'testing' }
 MicAbstractBlock >> listItemBlockClass [
 	^ MicListItemBlock
 ]

--- a/src/Microdown/MicHeaderBlock.class.st
+++ b/src/Microdown/MicHeaderBlock.class.st
@@ -75,6 +75,11 @@ MicHeaderBlock >> headerElements: aCollection [
 	
 ]
 
+{ #category : 'testing' }
+MicHeaderBlock >> isHeader [
+	^ true
+]
+
 { #category : 'accessing' }
 MicHeaderBlock >> level [
 	^ level

--- a/src/Microdown/SequenceableCollection.extension.st
+++ b/src/Microdown/SequenceableCollection.extension.st
@@ -23,9 +23,3 @@ SequenceableCollection >> splitOnFirst: anObject noneValue: aValue [
 	^ { self copyFrom: 1 to: element -1 . self copyFrom: element + 1 to: self size }  
 	
 ]
-
-{ #category : '*Microdown' }
-SequenceableCollection >> trimBoth [
-
-	^ self
-]


### PR DESCRIPTION
Move extensions to proper places:
 - to the defining classes if possible
 - to the user if (and very clear) there is only one
 - close to other similar extensions if possible

Related to https://github.com/pharo-project/pharo/pull/19150