### PR TITLE
Fixed MicAbsoluteResourceReference path in case of Windows drive letter leading.

### DIFF
--- a/src/Microdown-Tests/MicrodownTest.class.st
+++ b/src/Microdown-Tests/MicrodownTest.class.st
@@ -66,6 +66,15 @@ Pharo is cool
 ' ].
 ]
 
+{ #category : 'tests' }
+MicrodownTest >> testAbsoluteWindowsPath [
+
+	| absoluteReference |
+	absoluteReference := MicAbsoluteResourceReference newFromUri:
+		                     (ZnUrl fromString: 'c:/temp/foo.txt').
+	self deny: (absoluteReference path beginsWith: '/')
+]
+
 { #category : 'tests - parent/children' }
 MicrodownTest >> testAddedAsChildWhenUsingParent [
 

--- a/src/Microdown-Tests/MicrodownTest.class.st
+++ b/src/Microdown-Tests/MicrodownTest.class.st
@@ -72,7 +72,8 @@ MicrodownTest >> testAbsoluteWindowsPath [
 	| absoluteReference |
 	absoluteReference := MicAbsoluteResourceReference newFromUri:
 		                     (ZnUrl fromString: 'c:/temp/foo.txt').
-	self deny: (absoluteReference path beginsWith: '/')
+	self deny: (OSPlatform current isWindows and: [
+			 absoluteReference path beginsWith: '/' ])
 ]
 
 { #category : 'tests - parent/children' }

--- a/src/Microdown/MicAbsoluteResourceReference.class.st
+++ b/src/Microdown/MicAbsoluteResourceReference.class.st
@@ -68,7 +68,22 @@ MicAbsoluteResourceReference >> loadMicrodown [
 { #category : 'accessing' }
 MicAbsoluteResourceReference >> path [
 	"return the path part of my uri"
-	^ '/', uri path
+
+	^ OSPlatform current isWindows
+		  ifTrue: [ self pathOnWindows ]
+		  ifFalse: [ self uriPathWithSlashPrefix ]
+]
+
+{ #category : 'private' }
+MicAbsoluteResourceReference >> pathOnWindows [
+	"Answer the path part of the uri in case of Windows."
+
+	" If a drive letter X: leads, no slash should be prefixed."
+
+	^ (uri path size > 2 and: [
+		   (AsciiCharset isLetter: uri path first) and: uri path second = $: ])
+		  ifTrue: [ uri path ]
+		  ifFalse: [ self uriPathWithSlashPrefix ]
 ]
 
 { #category : 'printing' }
@@ -97,6 +112,13 @@ MicAbsoluteResourceReference >> uri [
 { #category : 'accessing' }
 MicAbsoluteResourceReference >> uri: aZnUrl [
 	uri := aZnUrl
+]
+
+{ #category : 'private' }
+MicAbsoluteResourceReference >> uriPathWithSlashPrefix [
+	"Answer the path part of my uri."
+
+	^ '/' , uri path
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
This is to solve issue #980. 