### PR TITLE
Fix/english typo

### DIFF
--- a/src/Microdown-Rules/MicEnglishTypographyChecker.class.st
+++ b/src/Microdown-Rules/MicEnglishTypographyChecker.class.st
@@ -54,7 +54,7 @@ checks := {
 		message := pair value.
 
 		matcher := RxMatcher forString: pattern.
-		(matcher matchesIn: aString) notEmpty ifTrue: [
+		(matcher matchesIn: cleanString) notEmpty ifTrue: [
 			self addResultFor: anElement message: message
 		]
 	].

--- a/src/Microdown-Rules/MicEnglishTypographyChecker.class.st
+++ b/src/Microdown-Rules/MicEnglishTypographyChecker.class.st
@@ -31,12 +31,14 @@ MicEnglishTypographyChecker >> addResultFor: anElement message: aMessage [
 
 { #category : 'adding' }
 MicEnglishTypographyChecker >> checkString: aString for: anElement [
-	| checks |
+	| checks cleanString |
 	aString ifNil: [ ^self ].
+	cleanString := aString copyReplaceAll: (String with: Character lf) with: ' '.
+	cleanString := cleanString copyReplaceAll: (String with: Character cr) with: ' '. 
 checks := {
 		' \:' -> 'There is a space before :'.
 		' \,' -> 'There is a space before ,'.
-		'\:[^ ]' -> 'There is no space after :'.
+		'\:[^ /]' -> 'There is no space after :'.
 		',[^ ]' -> 'There is no space after ,'.
 		' \;' -> 'There is a space before ;'.
 		'\;[^ ]' -> 'There is no space after ;'.

--- a/src/Microdown-Rules/MicEnglishTypographyCheckerTest.class.st
+++ b/src/Microdown-Rules/MicEnglishTypographyCheckerTest.class.st
@@ -58,6 +58,17 @@ collection do: [:each | each printString' ].
 	file writeStreamDo: [ :stream |
 			stream nextPutAll: 'Visit http://pharo.org for details.' ].
 
+	file := fileSystem workingDirectory / 'colonNewline.md'.
+	file writeStreamDo: [ :stream |
+			stream nextPutAll: 'Here is a list: - item one' ].
+		
+	file := fileSystem workingDirectory / 'commaNewline.md'.
+	file writeStreamDo: [ :stream |
+			stream nextPutAll: 'First, second.' ].
+		
+	file := fileSystem workingDirectory / 'semicolonNewline.md'.
+	file writeStreamDo: [ :stream |
+			stream nextPutAll: 'First; second.' ].
 	
 ]
 
@@ -87,6 +98,20 @@ MicEnglishTypographyCheckerTest >> testMonospaceIgnored [
 ]
 
 { #category : 'tests' }
+MicEnglishTypographyCheckerTest >> testNoFalsePositiveForColonNewline [
+
+	checker checkProject: fileSystem / 'colonNewline.md'.
+	self assert: checker isOkay.
+]
+
+{ #category : 'tests' }
+MicEnglishTypographyCheckerTest >> testNoFalsePositiveForCommaline [
+
+	checker checkProject: fileSystem / 'commaNewline.md'.
+	self assert: checker isOkay.
+]
+
+{ #category : 'tests' }
 MicEnglishTypographyCheckerTest >> testNoFalsePositiveForHTTPSURL [
 
 	checker checkProject: fileSystem / 'urlHTTPS.md'.
@@ -97,6 +122,13 @@ MicEnglishTypographyCheckerTest >> testNoFalsePositiveForHTTPSURL [
 MicEnglishTypographyCheckerTest >> testNoFalsePositiveForHTTPURL [
 
 	checker checkProject: fileSystem / 'urlHTTP.md'.
+	self assert: checker isOkay.
+]
+
+{ #category : 'tests' }
+MicEnglishTypographyCheckerTest >> testNoFalsePositiveForSemicolonNewline [
+
+	checker checkProject: fileSystem / 'semicolonNewline.md'.
 	self assert: checker isOkay.
 ]
 

--- a/src/Microdown-Rules/MicEnglishTypographyCheckerTest.class.st
+++ b/src/Microdown-Rules/MicEnglishTypographyCheckerTest.class.st
@@ -50,7 +50,13 @@ This is correct: example, test.' ].
 ```smalltalk
 collection do: [:each | each printString' ].
 
+	file := fileSystem workingDirectory / 'urlHTTPS.md'.
+	file writeStreamDo: [ :stream |
+			stream nextPutAll: 'See https://books.pharo.org for more.' ].
 
+	file := fileSystem workingDirectory / 'urlHTTP.md'.
+	file writeStreamDo: [ :stream |
+			stream nextPutAll: 'Visit http://pharo.org for details.' ].
 
 	
 ]
@@ -77,6 +83,20 @@ MicEnglishTypographyCheckerTest >> testCorrectFile [
 MicEnglishTypographyCheckerTest >> testMonospaceIgnored [
 
 	checker checkProject: fileSystem / 'mono.md'.
+	self assert: checker isOkay.
+]
+
+{ #category : 'tests' }
+MicEnglishTypographyCheckerTest >> testNoFalsePositiveForHTTPSURL [
+
+	checker checkProject: fileSystem / 'urlHTTPS.md'.
+	self assert: checker isOkay.
+]
+
+{ #category : 'tests' }
+MicEnglishTypographyCheckerTest >> testNoFalsePositiveForHTTPURL [
+
+	checker checkProject: fileSystem / 'urlHTTP.md'.
 	self assert: checker isOkay.
 ]
 


### PR DESCRIPTION
Fixes #1015

Fix false positives in MicEnglishTypographyChecker (fixes #1015):

- Ignore URLs (http:// and https://) in colon check: `\:[^ /]` instead of `\:[^ ]`
- Ignore newlines after punctuation (,  :  ;  ?  !) by replacing newlines with spaces before checking

Result:

File index.md has reference problems.

## English Typography Violations

- Text: " :" in file/home/fanirindrainy/Booklet-TestingInPharo/Chapters/Web/Web.md contains a mistake: There is a space before :
